### PR TITLE
ci: combine actions/setup-node 7.0.0 + actions/checkout 7.0.1 bumps (supersedes #168, #169)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: '20'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
@@ -120,7 +120,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240  # v2.37.2

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240  # v2.37.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
       # Checkout
       # =====================================================================
       - name: "📥 Checkout code"
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0  # Full history for changelog generation
 

--- a/.github/workflows/sftp-deploy.yml
+++ b/.github/workflows/sftp-deploy.yml
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240  # v2.37.2
@@ -185,7 +185,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Configure lftp timeouts
         run: |

--- a/.github/workflows/sftp-deploy.yml
+++ b/.github/workflows/sftp-deploy.yml
@@ -116,7 +116,7 @@ jobs:
           parallel-lint --exclude vendor --exclude _libraries --exclude .git web/
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: '20'
 


### PR DESCRIPTION
## 📋 Summary

Combines the two open Dependabot GitHub Actions bumps into a **single mergeable PR** against `main`, to minimise the risk of PR race conditions (two PRs touching the same workflow files landing separately).

Supersedes:
- #168 — `actions/setup-node` 4.4.0 → 7.0.0
- #169 — `actions/checkout` 7.0.0 → 7.0.1

## 🔄 Changes

Pin updates across all workflow files (SHA-pinned, comment shows the tag):

| Action | From | To | Files |
|---|---|---|---|
| `actions/setup-node` | v4.4.0 | v7.0.0 | `ci.yml`, `sftp-deploy.yml` |
| `actions/checkout` | v7.0.0 | v7.0.1 | `ci.yml`, `php-lint.yml`, `release.yml`, `sftp-deploy.yml` |

8 pin lines changed, no logic changes. Diff is byte-for-byte the union of #168 and #169.

## 🧩 Component(s)

- [x] CI/CD / Infrastructure

## ✅ Testing

- [x] PHP lint / CI workflows re-run against the bumped actions
- [x] `actions/setup-node@v7` requires Node ≥ 20; workflows already pin `node-version: '20'` ✔

## 📝 Notes

Once merged, #168 and #169 can be closed as superseded. The same bumps are being propagated to the `alpha` line via PR #170, and Dependabot config is being extended to target `alpha`/`beta` to prevent this drift going forward.

---

> Tracked on the [Go2My.Link Project Board](https://github.com/orgs/MWBMPartners/projects/4)

---
_Generated by [Claude Code](https://claude.ai/code/session_019v28sGYqnGeBSPNbGgVwgJ)_