### PR TITLE
ci(dependabot): cover all three tiers (main/alpha/beta) + group action bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,30 @@
 # =============================================================================
 #
 # Monitors GitHub Actions for dependency updates.
-# No Composer/npm dependencies to monitor (Dreamhost has no CLI).
+# No Composer/npm dependencies to monitor (Dreamhost has no CLI), so the only
+# ecosystem tracked is "github-actions" (the workflow action pins themselves).
+#
+# THREE-TIER COVERAGE (alpha > beta > main)
+# -----------------------------------------------------------------------------
+# Dependabot reads this file ONLY from the default branch (main), but each
+# `updates` entry can point at a different branch via `target-branch`. We
+# therefore declare one entry per tier so version-update PRs are opened against
+# ALL THREE branches, not just main. This closes the drift/variance gap where
+# alpha and beta (which may be deployed for small-group testing) would otherwise
+# fall behind main on action pins.
+#
+# GROUPING: each entry groups every github-actions bump into ONE pull request
+# per branch (a "grouped update"), so a week's action bumps arrive as a single
+# mergeable PR per tier instead of several racing PRs (see #168/#169/#171).
+#
+# NOTE ON SECURITY UPDATES (owner action, tracked in the launch checklist):
+#   Dependabot *security* updates (the automatic CVE-patch PRs, distinct from
+#   these scheduled *version* updates) are a repository setting and ALWAYS
+#   target the default branch — GitHub does not let `target-branch` retarget
+#   them. To keep alpha/beta patched for security we rely on (a) these version
+#   updates, and (b) regular promotion of main's fixes down the tiers. Enabling
+#   "Dependabot security updates" + secret scanning + push protection in the
+#   repo Security settings is tracked as a pre-launch owner action.
 #
 # @package    Go2My.Link
 # @author     MWBM Partners Ltd (MWservices)
@@ -19,9 +42,12 @@
 version: 2
 
 updates:
-  # Monitor GitHub Actions versions
+  # ---------------------------------------------------------------------------
+  # main — production tier (default branch)
+  # ---------------------------------------------------------------------------
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -29,3 +55,46 @@ updates:
       - "infrastructure"
     commit-message:
       prefix: "ci"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # ---------------------------------------------------------------------------
+  # alpha — earliest dev tier (small-group testing may be deployed here)
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "alpha"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "infrastructure"
+    commit-message:
+      prefix: "ci"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # ---------------------------------------------------------------------------
+  # beta — testing tier (small-group testing may be deployed here)
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "beta"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "infrastructure"
+    commit-message:
+      prefix: "ci"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## 📋 Summary

Extends Dependabot from **main-only** to our full **three-tier** model (`alpha > beta > main`) so `alpha` and `beta` — which may be deployed for small-group testing — no longer drift behind `main` on GitHub Actions pins.

## 🔄 Changes

`.github/dependabot.yml`:
- One `updates` entry **per tier** using `target-branch: main | alpha | beta`, so version-update PRs are opened against **all three** branches. (Dependabot only reads this file from the default branch, but honours per-entry `target-branch`.)
- **Grouped updates**: all `github-actions` bumps collapse into **one PR per branch**, so a week's pins arrive as a single mergeable PR per tier instead of racing PRs — the exact problem #168/#169 caused (resolved manually in #171).
- `open-pull-requests-limit: 10` and preserved `infrastructure` label + `ci` commit prefix.

## 🧩 Component(s)

- [x] CI/CD / Infrastructure

## ✅ Testing

- [x] `yaml.safe_load` validates; v2 schema, 3 tiers, all grouped.

## 📝 Notes / Owner action

Dependabot **security** updates (CVE auto-patch PRs, distinct from these scheduled version updates) are a repo setting and **always target the default branch** — GitHub does not allow `target-branch` to retarget them. Keeping `alpha`/`beta` security-patched therefore relies on these version updates **plus** regular promotion of `main` fixes down the tiers. Enabling *Dependabot security updates*, *secret scanning*, and *push protection* in repo Security settings is captured in the pre-launch checklist.

---

> Tracked on the [Go2My.Link Project Board](https://github.com/orgs/MWBMPartners/projects/4)

---
_Generated by [Claude Code](https://claude.ai/code/session_019v28sGYqnGeBSPNbGgVwgJ)_