### PR TITLE
docs+ci: pre-launch checklist, handoff refresh, Dependabot sync to alpha

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,30 @@
 # =============================================================================
 #
 # Monitors GitHub Actions for dependency updates.
-# No Composer/npm dependencies to monitor (Dreamhost has no CLI).
+# No Composer/npm dependencies to monitor (Dreamhost has no CLI), so the only
+# ecosystem tracked is "github-actions" (the workflow action pins themselves).
+#
+# THREE-TIER COVERAGE (alpha > beta > main)
+# -----------------------------------------------------------------------------
+# Dependabot reads this file ONLY from the default branch (main), but each
+# `updates` entry can point at a different branch via `target-branch`. We
+# therefore declare one entry per tier so version-update PRs are opened against
+# ALL THREE branches, not just main. This closes the drift/variance gap where
+# alpha and beta (which may be deployed for small-group testing) would otherwise
+# fall behind main on action pins.
+#
+# GROUPING: each entry groups every github-actions bump into ONE pull request
+# per branch (a "grouped update"), so a week's action bumps arrive as a single
+# mergeable PR per tier instead of several racing PRs (see #168/#169/#171).
+#
+# NOTE ON SECURITY UPDATES (owner action, tracked in the launch checklist):
+#   Dependabot *security* updates (the automatic CVE-patch PRs, distinct from
+#   these scheduled *version* updates) are a repository setting and ALWAYS
+#   target the default branch — GitHub does not let `target-branch` retarget
+#   them. To keep alpha/beta patched for security we rely on (a) these version
+#   updates, and (b) regular promotion of main's fixes down the tiers. Enabling
+#   "Dependabot security updates" + secret scanning + push protection in the
+#   repo Security settings is tracked as a pre-launch owner action.
 #
 # @package    Go2My.Link
 # @author     MWBM Partners Ltd (MWservices)
@@ -19,9 +42,12 @@
 version: 2
 
 updates:
-  # Monitor GitHub Actions versions
+  # ---------------------------------------------------------------------------
+  # main — production tier (default branch)
+  # ---------------------------------------------------------------------------
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -29,3 +55,46 @@ updates:
       - "infrastructure"
     commit-message:
       prefix: "ci"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # ---------------------------------------------------------------------------
+  # alpha — earliest dev tier (small-group testing may be deployed here)
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "alpha"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "infrastructure"
+    commit-message:
+      prefix: "ci"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # ---------------------------------------------------------------------------
+  # beta — testing tier (small-group testing may be deployed here)
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "beta"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "infrastructure"
+    commit-message:
+      prefix: "ci"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -3,7 +3,7 @@
 > **Purpose:** durable pick-up point so any session (or a fresh start) can continue
 > without re-deriving state. Companion to `docs/LAUNCH_PLAN_2026-07-09.md` (the full
 > strategic plan) and `.claude/memory/MEMORY.md` (project memory).
-> **Last updated:** 2026-07-19 (post-recovery conformance audit) · **Branch:** `launch-prep/2026-07-09`.
+> **Last updated:** 2026-07-22 (automation session: PR merges, Dependabot 3-tier, pricing) · earlier: 2026-07-19 (post-recovery conformance audit) · **Branch:** `alpha` (launch-prep merged in).
 > **Status:** recovery + cross-device reconciliation complete and **independently verified**. A
 > full conformance audit of **all 156 issues + the project brief against the actual code** then
 > ran. It found **no closed issue whose code is missing** — the recovery is sound — but it did
@@ -13,6 +13,19 @@
 ---
 
 ## ▶️ START HERE — pick-up point (next session / owner)
+
+### 🗓️ 2026-07-22 update (automation session)
+
+- Merged the two Dependabot bumps as a single PR **#171 → `main`** (#168/#169 superseded & closed).
+- Merged the full launch-prep branch **#170 → `alpha`** (alpha now carries API v1, Component C,
+  analytics, entitlements, GDPR export, etc.), with the `checkout` v7.0.1 bump propagated first.
+- **#172 → `main`**: Dependabot now covers **all three tiers** (`main`/`alpha`/`beta`) and **groups**
+  action bumps into one PR per branch (kills the #168/#169-style race). This session also syncs the
+  same `.github/dependabot.yml` forward onto `alpha`.
+- Added **`PRE_LAUNCH_CHECKLIST.md`** — owner decisions + manual actions; **read it before launch**.
+- Flexible **pricing/tiering** model + `Pricing_Strategy.md` being designed and scaffolded *disabled*.
+- A full open+closed **issue review** is running to drive the next prioritized/bundled work.
+- ⚠️ Still true: do **NOT** merge stale `main` down into `alpha`/`beta`.
 
 **State in one line:** the codebase is in good shape and the recovery is verified, but launch is
 **no longer** gated only on owner actions — the conformance audit found real code gaps, two of

--- a/PRE_LAUNCH_CHECKLIST.md
+++ b/PRE_LAUNCH_CHECKLIST.md
@@ -1,0 +1,66 @@
+# 🚦 Go2My.Link — Pre-Launch Checklist, Owner Decisions & Actions
+
+> **Purpose:** the single page to run through **before launching the service**. It captures
+> (a) decisions only the owner (Lance) can make, (b) manual actions outside the codebase
+> (GitHub settings, DNS, credentials, payment providers), and (c) a log of what automation
+> did on your behalf. Companion to `HANDOFF.md` (technical pick-up state), `PROJECT_STATUS.md`,
+> and `docs/LAUNCH_PLAN_2026-07-09.md`.
+>
+> **Legend:** 🔴 launch-blocking · 🟠 important · 🟢 nice-to-have · ✅ done · ⏳ in progress · ❓ needs your decision
+>
+> **Last updated:** 2026-07-22
+
+---
+
+## ❓ Owner decisions needed (please read first)
+
+| # | Decision | Why it matters | Options / recommendation |
+|---|---|---|---|
+| D1 🔴 | **How does periodic/scheduled work run on Dreamhost shared hosting?** (no assumable cron) | Blocks GDPR **account-deletion execution (#163)** and **data-retention enforcement (#167)** — the privacy policy legally commits to both. Also affects log purging, trial expiry, subscription renewals. | (a) Dreamhost Panel cron jobs (simplest, native); (b) external scheduler (cron-job.org / GitHub Actions `schedule:`) hitting a **token-guarded** `/_cron/run.php` endpoint; (c) run-on-request "lazy cron". **Recommendation: (b)** — portable, testable, provider-agnostic, works today. Decide once → unblocks #163, #167 and future billing jobs. |
+| D2 🔴 | **When do we promote `alpha → beta → main` for the real production launch?** | `main` is **stale** (still the legacy engine + the #93 credential file — HANDOFF warns *do not merge main*). All the real launch-prep work lives on `alpha` (90 commits ahead). Production go-live = a deliberate promotion, not automatic. | Needs owner sign-off + a cutover window. Dependabot/CI now cover all tiers so the mechanics are ready. **Do not** let anything merge `main` back down. |
+| D3 🟠 | **Payment provider** for paid tiers (Stripe / Paddle / other)? | The billing schema is provider-agnostic (`paymentProvider` column) but integration code + webhook endpoints need a concrete choice. Paddle acts as merchant-of-record (handles VAT/MoSS) — attractive for a UK/EU SaaS. | Choose before enabling any paid tier. Pricing model (below) is being designed provider-neutral. |
+| D4 🟠 | **Pricing & tier sign-off** | The flexible tiering/pricing model + `Pricing_Strategy.md` are being authored this session. Feature→tier mapping and price points need your approval before go-live. | Review `Pricing_Strategy.md` when delivered; the entitlement scaffolding ships **disabled** until you say go. |
+| D5 🟠 | **`beta` branch drift** — align it to `alpha` conventions? | `beta` uses floating action tags (`@v7`/`@v4`) and lacks the `lint.yml` (actionlint) workflow that `alpha`/`main` have — a source of the exact variance you flagged. | Recommend a one-off "align beta CI + SHA-pin actions" PR (tracked as an issue this session). Low risk. |
+
+---
+
+## 🔒 Manual actions outside the codebase (owner must do in GitHub / hosting)
+
+| # | Action | Status |
+|---|---|---|
+| A1 🔴 | **Rotate the legacy DB credential (#93)** that was in `web/G2My.Link/public_html_legacy/dbConfig.php` (treat as compromised) and remove/archive that legacy dir. | ❓ verify done |
+| A2 🟠 | **GitHub → Settings → Security:** enable **Dependabot security updates**, **Secret scanning**, and **Push protection**. Dependabot *version* updates now target all 3 tiers (done in code); *security* updates are a repo setting and only target the default branch. | ⏳ owner toggle |
+| A3 🟠 | **Legal review** of the legal pages (terms/privacy/cookies/copyright/acceptable-use) — they contain `{{LEGAL_REVIEW_NEEDED}}` placeholders and publish retention promises that must match what the code enforces (see #167). | ⏳ |
+| A4 🟢 | Confirm **DNS / TLS** for all three domains (go2my.link, g2my.link, lnks.page) + admin subdomain before public launch. | ⏳ |
+| A5 🟢 | Provide **MaxMind license/secret** if country-level analytics geolocation (#43) should be enabled (currently gated off, graceful-absent). | ⏳ |
+
+---
+
+## 🤖 Done autonomously this session (2026-07-22) — for your visibility
+
+| Change | Detail |
+|---|---|
+| ✅ **PR #171 → `main`** (merged) | Combined the two Dependabot bumps `actions/setup-node`→v7.0.0 (#168) + `actions/checkout`→v7.0.1 (#169) into **one** mergeable PR to remove the PR race; #168/#169 closed as superseded. |
+| ✅ **PR #170 → `alpha`** (merged) | Propagated the still-needed `checkout` v7.0.1 bump onto the launch-prep branch (setup-node v7.0.0 was already there), CI green, merged the full launch-prep integration into `alpha`. |
+| ✅ **PR #172 → `main`** (merged) | Rewrote `.github/dependabot.yml` to cover **all three tiers** (`target-branch: main/alpha/beta`) and **group** action bumps into one PR per branch — so future weeks won't recreate the #168/#169 race. |
+| ⏳ **Flexible pricing/tiering** | `Pricing_Strategy.md` + an unlimited-tiers/unlimited-features/flexible-pricing data model are being designed and scaffolded **disabled** (see D4). |
+| ⏳ **Backlog review + next steps** | A full open+closed GitHub-issue review is running to drive prioritized follow-up work (each item gets an issue, commit, and handoff update). |
+
+---
+
+## 📌 Open backlog highlights (populated from the issue review — see HANDOFF.md for the live list)
+
+_This section is filled in as the backlog review completes; the authoritative live list lives in
+`HANDOFF.md` and the GitHub issue tracker. Known launch-relevant items carried over from the
+2026-07-19 conformance audit:_
+
+- 🔴 **#163** — account-deletion requests are never executed (blocked on D1).
+- 🔴 **#167** — published data-retention periods are not enforced (blocked on D1).
+- 🟠 **#165** — individually-registered users (the `[default]` org) get **no analytics**.
+- 🟠 **#166** — short URLs can be minted on an **unverified** custom domain → dead links.
+- 🟠 **#164** — analytics KPI tiles render **raw translation keys** (keys used but never seeded).
+- ✅ **#162** — GDPR data-export download — **fixed** in the launch-prep merge (verify issue closed).
+
+---
+
+_This file is maintained continuously. If a session ends unexpectedly, start here + `HANDOFF.md`._


### PR DESCRIPTION
## 📋 Summary

Session bookkeeping + anti-drift, no product code changes.

## 🔄 Changes

- **`PRE_LAUNCH_CHECKLIST.md`** (new) — the single page to run through before launch: owner
  decisions (Dreamhost scheduling for GDPR jobs, `alpha→beta→main` production promotion, payment
  provider, pricing sign-off, `beta` drift), manual actions (legacy-credential rotation #93, repo
  Security settings, legal review), and a log of what automation landed this session.
- **`HANDOFF.md`** — adds a 2026-07-22 session section (outcomes of PR #171/#170/#172).
- **`.github/dependabot.yml`** — synced onto `alpha` to match `main`'s three-tier config
  (`main`/`alpha`/`beta`) so the config file itself doesn't drift between tiers.

## 🧩 Component(s)

- [x] CI/CD / Infrastructure
- [x] Docs

## ✅ Testing

- [x] `dependabot.yml` validates (v2, 3 tiers, grouped) and is byte-identical to `main`'s.
- [x] Markdown only otherwise.

---

> Tracked on the [Go2My.Link Project Board](https://github.com/orgs/MWBMPartners/projects/4)

---
_Generated by [Claude Code](https://claude.ai/code/session_019v28sGYqnGeBSPNbGgVwgJ)_