### PR TITLE
fix(#166): don't mint short URLs on unverified custom domains (dead links)

### DIFF
--- a/web/Go2My.Link/_functions/shorturl_create.php
+++ b/web/Go2My.Link/_functions/shorturl_create.php
@@ -1161,8 +1161,19 @@ function checkAnonymousRateLimit(string $ipAddress): array
 // ============================================================================
 // 🌐 getDefaultShortDomain — Get the default short domain for an org
 // ============================================================================
-// Queries tblOrgShortDomains for the default active short domain of the
-// given organisation. Falls back to 'g2my.link'.
+// Queries tblOrgShortDomains for the default active AND VERIFIED short domain
+// of the given organisation. Falls back to 'g2my.link'.
+//
+// #166: this MUST mirror the redirect resolver's acceptance condition exactly.
+// The resolver (web/G2My.Link/_functions/domain_resolver.php) only serves a
+// short domain when `verificationStatus = 'verified' AND isActive = 1`. If we
+// minted short URLs on a merely-active-but-unverified default domain, the
+// resolver would then refuse to serve them -> dead links. Requiring
+// verificationStatus = 'verified' here can only PREVENT dead links: any domain
+// that currently resolves already satisfies this (it could not resolve
+// otherwise), so grandfathered/migrated domains — which migration 013 marks
+// verified so they keep resolving — are unaffected. When no verified default
+// domain exists we fall back to 'g2my.link', which is always routable.
 //
 // @param  string $orgHandle  The organisation handle
 // @return string             The short domain (e.g., 'g2my.link', 'camsda.link')
@@ -1175,6 +1186,7 @@ function getDefaultShortDomain(string $orgHandle): string
          WHERE orgHandle = ?
            AND isDefault = 1
            AND isActive = 1
+           AND verificationStatus = 'verified'
          LIMIT 1",
         's',
         [$orgHandle]


### PR DESCRIPTION
## 📋 Summary

Closes **#166**. `getDefaultShortDomain()` selected an org's default short domain filtering only on `isDefault = 1 AND isActive = 1`, **ignoring `verificationStatus`**. The redirect resolver (`web/G2My.Link/_functions/domain_resolver.php:94`) only serves a short domain when `verificationStatus = 'verified' AND isActive = 1` — so any short URL minted on a merely-active-but-*unverified* default domain resolved to a **dead link**.

## 🔄 Change

One-line WHERE tightening in `getDefaultShortDomain()` (+ explanatory comment):

```sql
   AND isDefault = 1
   AND isActive = 1
   AND verificationStatus = 'verified'   -- NEW: mirror the resolver exactly
```

**Why this is safe:** it can only *prevent* dead links. A domain that currently resolves already satisfies `verificationStatus = 'verified'` (it could not resolve otherwise), so grandfathered/migrated domains — which migration 013 marks verified so they keep resolving — are unaffected. With no verified default domain, it falls back to `g2my.link`, which is always routable. All callers use `function_exists()` guards and simply receive a routable domain instead of a possibly-dead one.

## 🧩 Component(s)

- [x] Component A — Main Website / Admin (short URL creation)
- [x] Shared

## ✅ Testing

- [x] `php -l` clean.
- [x] Mirrors the already-tested resolver condition (`tests/integration/custom_domain_verification_test.php` covers verification→routability). A dedicated creation-path integration test is noted as a follow-up once the advisory integration CI job is promoted to required.

## 🔗 Related

Closes #166.

---

> Tracked on the [Go2My.Link Project Board](https://github.com/orgs/MWBMPartners/projects/4)

---
_Generated by [Claude Code](https://claude.ai/code/session_019v28sGYqnGeBSPNbGgVwgJ)_