### PR TITLE
feat(pricing): flexible tier/pricing engine scaffolding — additive & DISABLED by default

### DIFF
--- a/Pricing_Strategy.md
+++ b/Pricing_Strategy.md
@@ -1,0 +1,245 @@
+# 💷 Go2My.Link — Pricing & Monetisation Strategy
+
+> ⚠️ **Status: DRAFT for owner review.** The **tier names**, **GBP price points**, and the
+> **decision to launch/enable billing** in this document are **NOT approved** and must not be
+> treated as final. Everything else here (the competitor scan, positioning, the pricing
+> *mechanics* the data model supports, and the launch posture) reflects the current build.
+> See [§7 Owner sign-off checklist](#7--owner-sign-off-checklist-answer-before-flipping-any-switch)
+> at the end of this document for the specific decisions required before any price is shown to
+> a customer or `billing.pricing_engine_enabled` is switched on.
+>
+> **Companion artifacts:**
+> [`web/_sql/schema/036_pricing_engine.sql`](web/_sql/schema/036_pricing_engine.sql) (data
+> model), [`web/_functions/pricing.php`](web/_functions/pricing.php) (resolver). Both ship as
+> **additive, disabled-by-default scaffolding** — see
+> [§6 Launch recommendation](#6--launch-recommendation).
+>
+> **Author context:** MWBM Partners Ltd (MWservices), UK. Base currency **GBP**.
+> Three components: A = go2my.link (main), B = g2my.link (redirect engine),
+> C = lnks.page (LinksPage / link-in-bio).
+
+---
+
+## 1. 🔍 Competitor scan (as of mid-2026)
+
+⚠️ Prices below are **indicative, as-of-2026**, gathered from public pricing pages and
+third-party pricing round-ups (sources at the end of this section). Competitors change
+prices frequently; re-verify before publishing any comparison. All competitor prices in
+**USD** as published (≈ £0.78/$1 at time of writing).
+
+| Competitor | Free tier | Entry paid | Mid | Top self-serve | Enterprise | What they gate hardest |
+|---|---|---|---|---|---|---|
+| **Bitly** | 10 links/mo, basic analytics | Core **$10/mo** (100 links, no custom domain) | Growth **$29–35/mo** (500 links, 1 custom domain, 4-mo click history) | Premium **$199/mo** (3k links, city analytics, 1-yr history) | Custom (~$10k+/yr) | Link volume, custom domains, click-history retention |
+| **Rebrandly** | ~500 branded links, 5k tracked clicks, watermarked QR | Essentials **$13/mo** ($8 annual) — 250 links, 1 domain, 10k clicks | Professional **$39/mo** — workspaces, teammates, password-protect | Growth (top self-serve) — deep links, roles | Custom | Tracked clicks, teammates, deep linking |
+| **Short.io** | 1,000 links, 5 domains, 50k clicks | Hobby **$5/mo** | Pro **$18/mo** — unlimited links/clicks, 10 domains | Team **$48/mo** — unlimited members, 50 domains, SLA | **$148/mo** — unlimited domains, SSO, S3 export | Domains, team size, data export |
+| **Dub.co** | 25 links/mo, 1k events, 3 domains, API + QR | Pro **$25/mo** (annual) — 1k links/mo, 50k events, 10 domains, 3 users | Business **$75/mo** — 10k links/mo, 250k events, webhooks, conversion tracking | Advanced **$250/mo** — 50k links/mo, 1M events | Custom — SSO/SAML, audit logs | "Events" (tracked clicks), links **per month**, retention, users |
+| **TinyURL** | Basic shortening + QR, no analytics | Pro **$16/mo** — 500 active URLs, custom domains, 10k API calls | Bulk **$83/mo** — 300k URLs, 100k API calls | — | Custom | Active-URL count, API calls |
+| **BL.INK** | None (21-day trial) | Expert+ **$48/mo** — 1 user, 1 domain, 10k links | SMB **$99/mo** — dynamic links | Team **$299/mo** (10 users) | Custom (compliance-focused) | Users, dynamic links, compliance |
+
+**Market observations that shape our design:**
+
+- 📊 Two dominant metering models: **active links** (Bitly, TinyURL) vs **links-created-per-month + tracked clicks/events** (Dub, Rebrandly, Short.io). Our schema must support *any* metering dimension — competitors have changed theirs repeatedly, and we should be able to as well without a schema change.
+- 🌐 Custom domains are the near-universal upgrade trigger; free tiers vary wildly (Short.io very generous, Bitly very stingy).
+- 🕓 **Analytics retention** is a quiet but effective gate (Bitly 30 days → 4 months → 1 year).
+- 💰 Annual discount is universally ~17–20% ("2 months free").
+- 🧩 Nobody in this set bundles link-in-bio **and** dynamic QR **and** shortener well at low price points — Bitly bundles all three but prices aggressively upward.
+
+**Sources** (retrieved 2026-07; indicative):
+[replug.io/blog/bitly-pricing](https://replug.io/blog/bitly-pricing) · [redirhub.com/blog/bitly-pricing-2026](https://www.redirhub.com/blog/bitly-pricing-2026) · [linklyhq.com/blog/bitly-enterprise-pricing](https://linklyhq.com/blog/bitly-enterprise-pricing) · [replug.io/blog/rebrandly-pricing](https://replug.io/blog/rebrandly-pricing) · [propicked.com/marketing/rebrandly/pricing](https://propicked.com/marketing/rebrandly/pricing) · [linklyhq.com/review/shortio](https://linklyhq.com/review/shortio) · [frontdeskreview.com/software/link-shorteners/short-io](https://frontdeskreview.com/software/link-shorteners/short-io/) · [linklyhq.com/review/dub](https://linklyhq.com/review/dub) · [dub.co/blog/new-pricing](https://dub.co/blog/new-pricing) · [linklyhq.com/review/tinyurl](https://linklyhq.com/review/tinyurl) · [spotsaas.com/product/tinyurl/pricing](https://www.spotsaas.com/product/tinyurl/pricing) · [softwaresuggest.com/bl-ink](https://www.softwaresuggest.com/bl-ink) · [capterra.com/p/189131/BL-INK](https://capterra.com/p/189131/BL-INK/)
+
+---
+
+## 2. 🎯 Positioning
+
+**Go2My.Link is the privacy-first, GDPR-native link platform — three products, one subscription, honest UK pricing.**
+
+- 🛡️ **Privacy-first / GDPR-native.** UK company, UK/EU data posture, consent-aware analytics (DNT respected, cookie-consent + data-rights tooling already shipped), country-level (not creepy person-level) geolocation via MaxMind. This is a *product* differentiator versus US incumbents, and a compliance necessity for UK/EU SMEs, agencies, public sector and charities.
+- 🧩 **Three products in one plan:** short links (A+B) + **dynamic QR with re-point & scan attribution** (CueRCode) + **LinksPage link-in-bio** (C) with custom domains and age-verification. Competitors charge separately or price the bundle high.
+- 🆓 **Unlimited anonymous shortening** stays free forever (top-of-funnel goodwill + brand distribution) — accounts add management, branding, analytics, and the two extra products.
+- 🇬🇧 **GBP-first, transparent pricing**, undercutting Bitly's ladder at every rung while being more generous than Bitly free and more honest than "unlimited*" claims.
+- 🔞 **Regulated-content readiness** (age-gate redirects, LinksPage age-verification) is a niche nobody above serves explicitly — price it into upper tiers.
+
+---
+
+## 3. 🪜 Recommended tier ladder — ⚠️ DRAFT, names/prices pending sign-off
+
+The data model supports **any number of tiers**; this is the recommended *launch* ladder. It
+reconciles today's mismatch (DB seeds `free/basic/premium/enterprise` vs marketing page
+`Free/Pro/Enterprise`) by **renaming, not deleting**: existing `tierID` slugs are kept as
+stable keys where possible, display names change.
+
+| | **Free** | **Starter** | **Pro** | **Business** | **Enterprise** |
+|---|---|---|---|---|---|
+| tierID (slug) | `free` (keep) | `basic` → display "Starter" | `premium` → display "Pro" | `business` (new row) | `enterprise` (keep) |
+| **Monthly (GBP)** | £0 | **£4** | **£12** | **£29** | from **£99** (custom) |
+| **Annual (GBP)** | £0 | **£40** (2 mo free) | **£120** (2 mo free) | **£290** (2 mo free) | custom |
+| **Lifetime** | — | £99 (founding, capped) | £249 (founding, capped 500) | — | — |
+| Target buyer | individuals, tyre-kickers | creators, sole traders | SMEs, marketers, devs | agencies, teams, regulated content | orgs needing DPA/SLA/volume |
+
+**Price rationale (proposal, not sign-off):**
+
+- **Starter £4** (~$5): matches Short.io Hobby, less than half Bitly Core — *and* includes a custom domain (Bitly Core has none). The "first paid pound" must be trivially easy to justify.
+- **Pro £12** (~$15): below Rebrandly Essentials-annualised + TinyURL Pro + Short.io Pro, while bundling advanced redirects, dynamic QR and LinksPage — features that cost $29–75/mo elsewhere. This is the anchor tier; most revenue should land here.
+- **Business £29** (~$37): agency/team price point at Bitly-Growth money but with 10 seats, custom-HTML LinksPage, priority support — an order of magnitude cheaper than functional equivalents (BL.INK Team $299, Dub Business $75).
+- **Enterprise from £99**: signal that a real enterprise offer exists (DPA, SLA, custom limits) without publishing a ceiling. Custom quotes via sales contact.
+- **Annual = exactly 2 months free (16.7%)** — industry-standard, easy to market ("2 months free"), simple maths in GBP.
+- **Lifetime (founding-member) deals**: `billingCycle ENUM` already includes `lifetime`. Cap units (`maxSubscriptions` in the price book) — e.g. 500 lifetime-Pro at £249 (≈21 months of Pro) — great early cash + community without long-tail liability. Retire the plan by flipping `isActive` off; existing holders are grandfathered automatically because subscriptions pin their plan.
+
+---
+
+## 4. 🧮 Feature-to-tier matrix — ⚠️ DRAFT values pending sign-off
+
+Granular feature slugs match the **feature registry** seeded by
+[`web/_sql/seeds/018_pricing_feature_registry.sql`](web/_sql/seeds/018_pricing_feature_registry.sql).
+`∞` = unlimited (NULL). Existing seed values are kept where sensible so current orgs see no
+regression.
+
+| Feature (registry slug) | Type | Free | Starter | Pro | Business | Enterprise |
+|---|---|---|---|---|---|---|
+| `links.max` (active short links) | limit | 50 | 500 | 5,000 | 25,000 | ∞ |
+| `links.custom_alias` | boolean | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `domains.custom_max` (verified short domains) | limit | 0 | 1 | 5 | 20 | ∞ |
+| `redirects.scheduled` | boolean | ❌ | ✅ | ✅ | ✅ | ✅ |
+| `redirects.device` | boolean | ❌ | ❌ | ✅ | ✅ | ✅ |
+| `redirects.geo` | boolean | ❌ | ❌ | ✅ | ✅ | ✅ |
+| `redirects.agegate` | boolean | ❌ | ❌ | ✅ | ✅ | ✅ |
+| `analytics.enabled` (dashboard) | boolean | ❌ | ✅ | ✅ | ✅ | ✅ |
+| `analytics.retention_days` | limit | 30 | 365 | 730 | 1,095 | ∞ |
+| `analytics.export_csv` | boolean | ❌ | ❌ | ✅ | ✅ | ✅ |
+| `analytics.geo_country` (MaxMind) | boolean | ❌ | ❌ | ✅ | ✅ | ✅ |
+| `api.access` | boolean | ❌ | ✅ | ✅ | ✅ | ✅ |
+| `api.requests_per_day` | quota | 100 | 5,000 | 50,000 | 250,000 | ∞ |
+| `api.bulk_endpoints` | boolean | ❌ | ❌ | ✅ | ✅ | ✅ |
+| `qr.dynamic` (CueRCode) | boolean | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `qr.scan_attribution` | boolean | ❌ | ✅ | ✅ | ✅ | ✅ |
+| `linkspage.pages_max` | limit | 1 | 3 | 10 | 50 | ∞ |
+| `linkspage.all_templates` | boolean | ❌ | ✅ | ✅ | ✅ | ✅ |
+| `linkspage.custom_domain` | boolean | ❌ | ❌ | ✅ | ✅ | ✅ |
+| `linkspage.agegate` | boolean | ❌ | ❌ | ✅ | ✅ | ✅ |
+| `linkspage.custom_html` ⚠️ high-risk | boolean | ❌ | ❌ | ⚠️ see note | ✅ | ✅ |
+| `org.seats` (users per org) | limit | 1 | 1 | 3 | 10 | ∞ |
+| `support.priority` | boolean | ❌ | ❌ | ❌ | ✅ | ✅ |
+
+> ⚠️ **`linkspage.custom_html` placement:** current seed grants `hasCustomHTML` at
+> `premium` (= new "Pro"). Recommendation: **move it up to Business** — it is the
+> highest stored-XSS-risk feature and belongs with a smaller, higher-trust cohort;
+> a paid add-on can offer it to Pro orgs case-by-case (per-org override). This is an
+> **open question for the owner** ([§7, Q3](#7--owner-sign-off-checklist-answer-before-flipping-any-switch)) — it changes an already-seeded grant.
+
+Legacy `has*`/`max*` columns map 1:1 into the registry (`hasAdvancedRedirects` becomes the
+umbrella; granular `redirects.*` slugs supersede it — the resolver treats "any granular
+redirect flag on" as the legacy flag for compatibility).
+
+---
+
+## 5. ⚙️ Pricing mechanics the data model supports
+
+Every mechanic below maps to a concrete structure in
+[`web/_sql/schema/036_pricing_engine.sql`](web/_sql/schema/036_pricing_engine.sql). These are
+**capabilities the schema was built to support**, not launch commitments — see
+[§6](#6--launch-recommendation) for what actually ships enabled.
+
+| # | Mechanic | How the model supports it |
+|---|---|---|
+| 1 | One-off discounts | `tblCoupons.discountKind` + `durationType='once'` |
+| 2 | Limited-time discounts | `tblCoupons.validFrom/validUntil` |
+| 3 | Lifetime discounts (forever off recurring) | `durationType='forever'` |
+| 4 | **Lifetime tiers** (pay once, keep tier) | `tblPricePlans.planType='lifetime'` (+ `maxSubscriptions` scarcity cap) |
+| 5 | Pay-as-you-go (PAYG) | `planType='payg'` + `meteredFeatureUID` + `unitPrice/unitSize` + `tblUsageCounters` |
+| 6 | **PAYG capped at flat-tier equivalent** | `planType='payg_capped'` + `capAmount` + `equivalentPlanUID` (cap defaults to that plan's price; `capBehaviour='flat_convert'` = "never pay more than Pro") |
+| 7 | Intro pricing | a second recurring plan on the same tier with `validUntil` + coupon `first_n_periods` |
+| 8 | Coupons / promo codes | `tblCoupons` (+ `tblCouponRedemptions` for per-org/total caps) |
+| 9 | Add-ons (e.g. +5 domains, custom-HTML for Pro) | `planType='addon'` plan → active sub grants a `tblOrgFeatureOverrides` row |
+| 10 | Annual discount | separate plan row `billingInterval='year'` priced at 10× monthly |
+| 11 | Per-seat vs per-org | `tblPricePlans.perSeatAmount` + `minSeats/maxSeats`; per-org = flat `amount` only |
+| 12 | Currency/region variants | many plan rows per tier: `currency` + `region` (e.g. GBP/GB default, EUR/EU, USD/ROW) |
+| 13 | Grandfathering | subscriptions pin `planUID` + `priceAtSubscription` in `tblSubscriptionPlans`; retiring a plan (`isActive=0`) never touches existing subs |
+| 14 | First-N-periods discounts | `tblCoupons.durationType='first_n_periods'` + `durationPeriods` |
+| 15 | Stacking rules | `tblCoupons.isStackable` + `stackingGroup` (same group never stacks) |
+
+**Additional flexibility, also supported by the model:**
+
+- 📏 **Arbitrary usage-metering dimensions** — any `tblFeatures` row with `isMeterable=1` can be metered (links created, tracked clicks, API calls, QR scans, LinksPage views…). Adding a dimension = 1 row.
+- 📅 **Entitlement effective-dating** — `tblTierFeatures` and `tblOrgFeatureOverrides` carry `effectiveFrom/effectiveUntil`: schedule a tier upgrade announcement ("from 1 Sep, Pro gets 10 domains") or a temporary comp, with zero code.
+- 🧪 **Trial→paid** — `tblPricePlans.trialDays` (feeds existing `tblSubscriptions.trialEndsAt`); recommend 14-day Pro trial, no card, for launch.
+- ➗ **Proration** — credit issuance as negative `one_off` payments referencing the sub; policy documented, executed at billing-integration time.
+- 🎟️ **Credit packs** — `planType='credit_pack'` (e.g. API-request top-ups) credit `tblUsageCredits`.
+- 🧬 **Price experiments** — multiple simultaneous active plans per tier; `isDefault` picks the advertised one per currency/region; cohorts keep whatever they signed on (grandfathering does the rest).
+- 🤝 **Referral / goodwill credits** — same credit mechanism as packs, `sourceType='comp'` overrides for feature comps.
+- 🎓 **Sector pricing** (charity/EDU) — dedicated coupons (`stackingGroup='sector'`) or hidden plans (`isVisible=0`).
+- 🚦 **Overage behaviour is data** — `capBehaviour ENUM('flat_convert','hard_stop','notify_only')` decides what happens at a cap, per plan, not per code path.
+
+---
+
+## 6. 🚀 Launch recommendation
+
+**Ships now, DISABLED (data present, switches off — zero behaviour change):**
+
+- The full data model (10 tables + verification view — schema `036`), the feature-registry
+  seed + legacy backfill (seed `018`), and the nine `billing.*` engine switches, **all seeded
+  `'0'`** (seed `019`).
+- The resolver (`web/_functions/pricing.php`) and its single guarded hook inside
+  `web/_functions/entitlements.php`'s `_g2ml_resolveOrgTier()`.
+- **The entire pricing engine remains behind `billing.pricing_engine_enabled=0`** until the
+  payment provider is integrated and the items in §7 are signed off — the platform keeps its
+  current "gate first, bill later" behaviour (GlobalAdmin assigns tiers manually) with
+  **zero behaviour change** on deploy. `entitlements.php`'s output is byte-identical to
+  before this scaffold landed.
+
+**Recommended to enable at launch, once §7 is signed off:**
+
+- Tiers Free/Starter/Pro/Business (Enterprise = "contact us" page, manual tier assignment — already possible today).
+- Monthly + annual GBP recurring plans; annual = 2 months free.
+- 14-day Pro trial (no card).
+- One launch coupon: e.g. `LAUNCH25` — 25% off first 3 months (`first_n_periods`), expiring 60–90 days post-launch.
+- Founding-member lifetime Pro (£249, cap 500) **only if** owner wants early cash-flow; otherwise defer.
+
+**Build now, keep DISABLED beyond launch:**
+
+- PAYG + PAYG-capped plans (`billing.payg_enabled=0`) — needs metering counters proven in production first.
+- Regional/currency price books (GBP only at launch; EUR/USD rows staged `isActive=0`).
+- Add-on & credit-pack plans; coupon stacking (`billing.coupon_stacking_enabled=0`).
+
+**Explicitly out of scope until later:** SSO/SAML, invoicing beyond provider receipts,
+VAT-inclusive display logic (needs owner/accountant decision — recommend showing ex-VAT for
+business tiers, and note UK VAT registration threshold considerations), crypto payments.
+
+**Recommended activation sequence** (see §7, Q10): deploy → run migration `020` (already-deployed
+DBs only; fresh installs pick up schema `036`/seeds `018`–`019` automatically) → run
+`tests/integration/pricing_backfill_verify.php` → flip `billing.pricing_engine_enabled` ON in a
+staging org only (Organisation-scope settings row) → flip System-wide once verified.
+
+---
+
+## 7. ❓ Owner sign-off checklist — answer before flipping any switch
+
+1. **Final tier names & slug policy** — keep slugs `free/basic/premium/enterprise`
+   with display renames (Starter/Pro), or mint new tier rows (`starter`, `pro`,
+   `business`) and retire old ones? (Slug-keep is zero-migration; new-slug is
+   cleaner but needs org reassignment.) Also: add the proposed **Business**
+   tier at all?
+2. **GBP price points** — sign off £4 / £12 / £29 (+ annual = 10× monthly) or
+   amend; Enterprise "from £99" vs pure "contact us".
+3. **`linkspage.custom_html` placement** — stay at Pro (parity with today's
+   `premium` seed) or move up to Business as recommended (risk containment)?
+   Moving it changes an already-seeded grant for existing `premium` orgs.
+4. **Free-tier API inconsistency (pre-existing)** — seed has `hasAPIAccess=0`
+   but `maxAPIRequestsPerDay=100` on `free`. This document's proposal is Free =
+   API access ON with 100/day; confirm or zero it.
+5. **Payment provider** — Stripe vs PayPal vs GoCardless (`tblSubscriptions`
+   provider fields currently name paypal/apple_pay/google_pay/crypto). The
+   schema is provider-agnostic (`metadataJSON` carries provider price IDs), but
+   the provider choice gates the billing-integration phase and webhook design —
+   and Dreamhost shared hosting favours redirect/hosted-checkout flows over
+   long-running webhook processors.
+6. **Lifetime founding-member deal** — run it? Cap (500?), price (£249 Pro /
+   £99 Starter), and whether `billing.lifetime_plans_enabled` flips at launch.
+7. **Launch coupon** — `LAUNCH25` 25%-off-3-months yes/no, expiry window.
+8. **VAT treatment** — display prices ex-VAT or inc-VAT; UK VAT registration
+   status/threshold plan (affects pricing-page copy, not schema).
+9. **Marketing-page reconciliation** — pricing page currently shows
+   Free/Pro/Enterprise vs 4 seeded tiers; when to update it to the final
+   ladder (needs `__('key')` i18n strings + WCAG-checked table).
+10. **When to flip** `billing.pricing_engine_enabled` — recommended: deploy →
+    run migration `020` → run `pricing_backfill_verify` → flip ON in staging org
+    only (Organisation-scope settings row) → flip System-wide.

--- a/tests/integration/pricing_backfill_verify.php
+++ b/tests/integration/pricing_backfill_verify.php
@@ -1,0 +1,414 @@
+<?php
+/**
+ * Copyright (c) 2024–2026 MWBM Partners Ltd (MWservices).
+ * All rights reserved.
+ *
+ * This source code is proprietary and confidential.
+ * Unauthorised copying, modification, or distribution is strictly prohibited.
+ */
+
+/**
+ * ============================================================================
+ * 🧪 Integration tests — pricing engine backfill verification (scaffold)
+ * ============================================================================
+ *
+ * Drives the REAL DB-backed pieces of the flexible pricing engine against a
+ * freshly imported test database (see tests/README.md):
+ *
+ *   (1) MIGRATION VERIFICATION — for every REAL seeded tier
+ *       (web/_sql/seeds/001_subscription_tiers.sql: free/basic/premium/
+ *       enterprise), vwSubscriptionTierEntitlements (schema 036) must match
+ *       tblSubscriptionTiers' legacy has* and max* columns column-for-column —
+ *       proving the seed-018 backfill reproduced the legacy model exactly.
+ *   (2) The nine billing.* engine-switch settings (seed 019) are present and
+ *       ALL seeded OFF ('0'), except the two non-switch display defaults
+ *       (currency/region) and the informational retention-days number.
+ *   (3) All 10 new tables (schema 036) exist.
+ *   (4) DISABLED-BY-DEFAULT: a freshly INSERTed tblPricePlans/tblCoupons row
+ *       that does not specify isActive lands isActive=0 (the launch-safe
+ *       posture), proven against the real column default rather than PHP.
+ *   (5) RESOLVER PARITY (end to end) — for a real org assigned to a real
+ *       seeded tier, web/_functions/pricing.php's g2ml_pricingResolveOrgTier()
+ *       (driven against the REAL database, no test overrides) produces the
+ *       SAME legacy-shaped values as entitlements.php's own legacy resolution
+ *       for that same org — proving the PHP resolver, not just the SQL view,
+ *       reproduces the legacy model exactly. This does NOT flip
+ *       billing.pricing_engine_enabled — it calls the resolver function
+ *       directly, exactly as tests/unit/pricing_resolver_test.php does.
+ *
+ * Registration model mirrors tests/integration/entitlements_test.php: cases
+ * register at INCLUDE time using the $db handle from run_integration.php's
+ * script scope. Helper names are prefixed g2ml_prbv_ to stay unique alongside
+ * the other integration files. With no reachable test DB the runner skips
+ * before this file is ever included.
+ *
+ * @package    Go2My.Link
+ * @subpackage Tests
+ * @since      v1.6.0 — Pricing Engine phase (scaffold)
+ * ============================================================================
+ */
+
+declare(strict_types=1);
+
+// ----------------------------------------------------------------------------
+// $db is provided by run_integration.php's script scope (a connected mysqli).
+// ----------------------------------------------------------------------------
+if (!isset($db) || !($db instanceof mysqli))
+{
+    return;
+}
+
+// ----------------------------------------------------------------------------
+// Point the application DB layer (getDB) at the same throwaway server. These
+// mirror run_integration.php's env resolution and are guarded so they compose
+// with any other integration file that already defined them.
+// ----------------------------------------------------------------------------
+if (!defined('DB_HOST'))
+{
+    $g2mlPrbvEnvHost = getenv('G2ML_TEST_DB_HOST');
+
+    if ($g2mlPrbvEnvHost === false || $g2mlPrbvEnvHost === '')
+    {
+        $g2mlPrbvEnvHost = '127.0.0.1';
+    }
+
+    define('DB_HOST', $g2mlPrbvEnvHost);
+}
+
+if (!defined('DB_PORT'))
+{
+    $g2mlPrbvEnvPort = getenv('G2ML_TEST_DB_PORT');
+
+    if ($g2mlPrbvEnvPort === false || $g2mlPrbvEnvPort === '')
+    {
+        $g2mlPrbvEnvPort = '3306';
+    }
+
+    define('DB_PORT', (int) $g2mlPrbvEnvPort);
+}
+
+if (!defined('DB_USER'))
+{
+    $g2mlPrbvEnvUser = getenv('G2ML_TEST_DB_USER');
+
+    if ($g2mlPrbvEnvUser === false || $g2mlPrbvEnvUser === '')
+    {
+        $g2mlPrbvEnvUser = 'root';
+    }
+
+    define('DB_USER', $g2mlPrbvEnvUser);
+}
+
+if (!defined('DB_PASS'))
+{
+    $g2mlPrbvEnvPass = getenv('G2ML_TEST_DB_PASS');
+
+    if ($g2mlPrbvEnvPass === false)
+    {
+        $g2mlPrbvEnvPass = '';
+    }
+
+    define('DB_PASS', $g2mlPrbvEnvPass);
+}
+
+if (!defined('DB_NAME'))
+{
+    $g2mlPrbvEnvName = getenv('G2ML_TEST_DB_NAME');
+
+    if ($g2mlPrbvEnvName === false || $g2mlPrbvEnvName === '')
+    {
+        $g2mlPrbvEnvName = 'mwtools_Go2MyLink';
+    }
+
+    define('DB_NAME', $g2mlPrbvEnvName);
+}
+
+if (!defined('DB_CHARSET'))
+{
+    define('DB_CHARSET', 'utf8mb4');
+}
+
+// ----------------------------------------------------------------------------
+// Load the real application function files the code under test depends on.
+// ----------------------------------------------------------------------------
+$g2mlPrbvFunctionsDir = dirname(__DIR__, 2) . '/web/_functions/';
+
+require_once $g2mlPrbvFunctionsDir . 'db_connect.php';
+require_once $g2mlPrbvFunctionsDir . 'db_query.php';
+require_once $g2mlPrbvFunctionsDir . 'security.php';
+require_once $g2mlPrbvFunctionsDir . 'settings.php';
+require_once $g2mlPrbvFunctionsDir . 'entitlements.php';
+require_once $g2mlPrbvFunctionsDir . 'pricing.php';
+
+// ----------------------------------------------------------------------------
+// Small DB helpers (prepared statements throughout).
+// ----------------------------------------------------------------------------
+
+/**
+ * Execute a setup/teardown query, aborting loudly on failure.
+ *
+ * @param  mysqli $db
+ * @param  string $sql
+ * @return void
+ */
+function g2ml_prbv_exec(mysqli $db, string $sql): void
+{
+    $result = mysqli_query($db, $sql);
+
+    if ($result === false)
+    {
+        throw new RuntimeException('Setup query failed: ' . mysqli_error($db) . ' — SQL: ' . $sql);
+    }
+}
+
+/**
+ * Fetch the tblSubscriptionTiers rows for the REAL seeded tiers (free/basic/
+ * premium/enterprise — see web/_sql/seeds/001_subscription_tiers.sql)
+ * alongside their vwSubscriptionTierEntitlements counterpart, one associative
+ * row per tier.
+ *
+ * Deliberately scoped to ONLY those four tierIDs rather than every row in
+ * tblSubscriptionTiers: several OTHER integration test files (e.g.
+ * tests/integration/api_key_test.php) insert their OWN throwaway test tiers
+ * directly into tblSubscriptionTiers for unrelated purposes. Those ad-hoc
+ * tiers are never backfilled into tblTierFeatures (the seed-018 backfill runs
+ * once, at import time, over whatever tiers existed then) — which is CORRECT
+ * behaviour (the legacy columns stay authoritative for them while the engine
+ * is off), not a pricing-engine defect, so this parity check must not treat
+ * their absence from the view as a mismatch.
+ *
+ * @param  mysqli $db
+ * @return array
+ */
+function g2ml_prbv_fetch_tier_vs_view(mysqli $db): array
+{
+    $result = mysqli_query(
+        $db,
+        'SELECT '
+        . 't.tierID, '
+        . 't.maxLinks AS legacyMaxLinks, v.maxLinks AS viewMaxLinks, '
+        . 't.maxCustomDomains AS legacyMaxCustomDomains, v.maxCustomDomains AS viewMaxCustomDomains, '
+        . 't.maxAPIRequestsPerDay AS legacyMaxAPIRequestsPerDay, v.maxAPIRequestsPerDay AS viewMaxAPIRequestsPerDay, '
+        . 't.maxLinksPages AS legacyMaxLinksPages, v.maxLinksPages AS viewMaxLinksPages, '
+        . 't.hasAdvancedRedirects AS legacyHasAdvancedRedirects, v.hasAdvancedRedirects AS viewHasAdvancedRedirects, '
+        . 't.hasAnalytics AS legacyHasAnalytics, v.hasAnalytics AS viewHasAnalytics, '
+        . 't.hasQRCodes AS legacyHasQRCodes, v.hasQRCodes AS viewHasQRCodes, '
+        . 't.hasAPIAccess AS legacyHasAPIAccess, v.hasAPIAccess AS viewHasAPIAccess, '
+        . 't.hasPrioritySupport AS legacyHasPrioritySupport, v.hasPrioritySupport AS viewHasPrioritySupport, '
+        . 't.hasCustomHTML AS legacyHasCustomHTML, v.hasCustomHTML AS viewHasCustomHTML '
+        . 'FROM tblSubscriptionTiers t '
+        . 'LEFT JOIN vwSubscriptionTierEntitlements v USING (tierID) '
+        . "WHERE t.tierID IN ('free', 'basic', 'premium', 'enterprise') "
+        . 'ORDER BY t.tierID ASC'
+    );
+
+    if ($result === false)
+    {
+        throw new RuntimeException('Query failed: ' . mysqli_error($db));
+    }
+
+    $rows = [];
+
+    while (($row = mysqli_fetch_assoc($result)) !== null)
+    {
+        $rows[] = $row;
+    }
+
+    mysqli_free_result($result);
+
+    return $rows;
+}
+
+// ----------------------------------------------------------------------------
+// 1. Migration verification — backfill parity via vwSubscriptionTierEntitlements.
+// ----------------------------------------------------------------------------
+test('pricing backfill: vwSubscriptionTierEntitlements matches tblSubscriptionTiers column-for-column for every real seeded tier', function () use ($db): void
+{
+    $rows = g2ml_prbv_fetch_tier_vs_view($db);
+
+    assert_same(4, count($rows), 'All 4 real seeded tiers (free/basic/premium/enterprise) are present');
+
+    foreach ($rows as $row)
+    {
+        $tierID = (string) $row['tierID'];
+
+        assert_same($row['legacyMaxLinks'], $row['viewMaxLinks'], 'maxLinks matches for tier ' . $tierID);
+        assert_same($row['legacyMaxCustomDomains'], $row['viewMaxCustomDomains'], 'maxCustomDomains matches for tier ' . $tierID);
+        assert_same($row['legacyMaxAPIRequestsPerDay'], $row['viewMaxAPIRequestsPerDay'], 'maxAPIRequestsPerDay matches for tier ' . $tierID);
+        assert_same($row['legacyMaxLinksPages'], $row['viewMaxLinksPages'], 'maxLinksPages matches for tier ' . $tierID);
+        assert_same($row['legacyHasAdvancedRedirects'], $row['viewHasAdvancedRedirects'], 'hasAdvancedRedirects matches for tier ' . $tierID);
+        assert_same($row['legacyHasAnalytics'], $row['viewHasAnalytics'], 'hasAnalytics matches for tier ' . $tierID);
+        assert_same($row['legacyHasQRCodes'], $row['viewHasQRCodes'], 'hasQRCodes matches for tier ' . $tierID);
+        assert_same($row['legacyHasAPIAccess'], $row['viewHasAPIAccess'], 'hasAPIAccess matches for tier ' . $tierID);
+        assert_same($row['legacyHasPrioritySupport'], $row['viewHasPrioritySupport'], 'hasPrioritySupport matches for tier ' . $tierID);
+        assert_same($row['legacyHasCustomHTML'], $row['viewHasCustomHTML'], 'hasCustomHTML matches for tier ' . $tierID);
+    }
+});
+
+// ----------------------------------------------------------------------------
+// 2. All billing.* settings exist and are seeded OFF (except display defaults).
+// ----------------------------------------------------------------------------
+test('pricing settings: every billing.* switch seeded OFF, except the currency/region display defaults', function () use ($db): void
+{
+    $result = mysqli_query($db, "SELECT settingID, settingValue FROM tblSettings WHERE settingID LIKE 'billing.%'");
+
+    if ($result === false)
+    {
+        throw new RuntimeException('Query failed: ' . mysqli_error($db));
+    }
+
+    $settings = [];
+
+    while (($row = mysqli_fetch_assoc($result)) !== null)
+    {
+        $settings[$row['settingID']] = $row['settingValue'];
+    }
+
+    mysqli_free_result($result);
+
+    $expectedOff = [
+        'billing.pricing_engine_enabled',
+        'billing.payg_enabled',
+        'billing.usage_metering_enabled',
+        'billing.usage_event_log_enabled',
+        'billing.lifetime_plans_enabled',
+        'billing.coupon_stacking_enabled',
+    ];
+
+    foreach ($expectedOff as $settingID)
+    {
+        assert_true(array_key_exists($settingID, $settings), $settingID . ' is seeded');
+        assert_same('0', $settings[$settingID], $settingID . ' is seeded OFF');
+    }
+
+    assert_same('GBP', $settings['billing.default_currency'] ?? null, 'default_currency display default is GBP');
+    assert_same('GB', $settings['billing.default_region'] ?? null, 'default_region display default is GB');
+    assert_same('90', $settings['billing.usage_event_retention_days'] ?? null, 'usage_event_retention_days default is 90');
+});
+
+// ----------------------------------------------------------------------------
+// 3. All 10 new tables exist.
+// ----------------------------------------------------------------------------
+test('pricing schema: all 10 new tables exist', function () use ($db): void
+{
+    $expectedTables = [
+        'tblFeatures',
+        'tblPricePlans',
+        'tblTierFeatures',
+        'tblOrgFeatureOverrides',
+        'tblCoupons',
+        'tblCouponRedemptions',
+        'tblSubscriptionPlans',
+        'tblUsageCounters',
+        'tblUsageCredits',
+        'tblUsageEvents',
+    ];
+
+    foreach ($expectedTables as $tableName)
+    {
+        $result = mysqli_query($db, 'SHOW TABLES LIKE \'' . $tableName . '\'');
+
+        if ($result === false)
+        {
+            throw new RuntimeException('Query failed: ' . mysqli_error($db));
+        }
+
+        $found = (mysqli_num_rows($result) === 1);
+        mysqli_free_result($result);
+
+        assert_true($found, $tableName . ' exists');
+    }
+});
+
+// ----------------------------------------------------------------------------
+// 4. DISABLED-BY-DEFAULT: a plan/coupon row lands isActive=0 without the
+//    caller specifying it.
+// ----------------------------------------------------------------------------
+test('pricing disabled-by-default: a new tblPricePlans/tblCoupons row defaults isActive=0', function () use ($db): void
+{
+    g2ml_prbv_exec($db, "INSERT INTO `tblPricePlans` (`planSlug`, `planName`) VALUES ('prbv-test-plan', 'PRBV Test Plan') ON DUPLICATE KEY UPDATE `planName` = VALUES(`planName`)");
+    g2ml_prbv_exec($db, "INSERT INTO `tblCoupons` (`couponName`) VALUES ('PRBV Test Coupon')");
+
+    $planResult = mysqli_query($db, "SELECT isActive FROM tblPricePlans WHERE planSlug = 'prbv-test-plan'");
+
+    if ($planResult === false)
+    {
+        throw new RuntimeException('Query failed: ' . mysqli_error($db));
+    }
+
+    $planRow = mysqli_fetch_assoc($planResult);
+    mysqli_free_result($planResult);
+
+    assert_same(0, (int) $planRow['isActive'], 'A newly inserted price plan defaults isActive=0');
+
+    $couponResult = mysqli_query($db, "SELECT isActive FROM tblCoupons WHERE couponName = 'PRBV Test Coupon'");
+
+    if ($couponResult === false)
+    {
+        throw new RuntimeException('Query failed: ' . mysqli_error($db));
+    }
+
+    $couponRow = mysqli_fetch_assoc($couponResult);
+    mysqli_free_result($couponResult);
+
+    assert_same(0, (int) $couponRow['isActive'], 'A newly inserted coupon defaults isActive=0');
+
+    g2ml_prbv_exec($db, "DELETE FROM `tblPricePlans` WHERE `planSlug` = 'prbv-test-plan'");
+    g2ml_prbv_exec($db, "DELETE FROM `tblCoupons` WHERE `couponName` = 'PRBV Test Coupon'");
+});
+
+// ----------------------------------------------------------------------------
+// 5. Resolver parity, end to end, against the REAL database (no overrides):
+//    g2ml_pricingResolveOrgTier() reproduces the legacy tier values for a real
+//    org/tier assignment.
+// ----------------------------------------------------------------------------
+test('pricing resolver parity: g2ml_pricingResolveOrgTier() matches the legacy tier for a real org, against the real database', function () use ($db): void
+{
+    g2ml_prbv_exec(
+        $db,
+        "INSERT INTO `tblOrganisations` (`orgHandle`, `orgName`, `orgFallbackURL`, `tierID`, `isActive`) "
+        . "VALUES ('prbv-test-org', 'PRBV Resolver Parity Org', 'https://go2my.link/prbv', 'free', 1) "
+        . "ON DUPLICATE KEY UPDATE `tierID` = VALUES(`tierID`), `isActive` = VALUES(`isActive`)"
+    );
+
+    if (function_exists('g2ml_clearOrgTierCache'))
+    {
+        g2ml_clearOrgTierCache('prbv-test-org');
+    }
+
+    if (function_exists('g2ml_clearPricingCache'))
+    {
+        g2ml_clearPricingCache('prbv-test-org');
+    }
+
+    $legacyTier   = g2ml_getOrgTier('prbv-test-org');
+    $resolvedTier = g2ml_pricingResolveOrgTier('prbv-test-org');
+
+    assert_true(is_array($resolvedTier), 'The pricing engine resolver succeeds against the real database');
+    assert_same('pricing_engine', $resolvedTier['source'], 'Precondition: resolvedTier really came from the pricing engine, not a fallback');
+    assert_same('tier', $legacyTier['source'], 'Precondition: legacyTier really came from the legacy tier lookup');
+
+    assert_same($legacyTier['tierID'], $resolvedTier['tierID'], 'tierID matches');
+    assert_same($legacyTier['maxLinks'], $resolvedTier['maxLinks'], 'maxLinks matches');
+    assert_same($legacyTier['maxCustomDomains'], $resolvedTier['maxCustomDomains'], 'maxCustomDomains matches');
+    assert_same($legacyTier['maxAPIRequestsPerDay'], $resolvedTier['maxAPIRequestsPerDay'], 'maxAPIRequestsPerDay matches');
+    assert_same($legacyTier['maxLinksPages'], $resolvedTier['maxLinksPages'], 'maxLinksPages matches');
+    assert_same($legacyTier['hasAdvancedRedirects'], $resolvedTier['hasAdvancedRedirects'], 'hasAdvancedRedirects matches');
+    assert_same($legacyTier['hasAnalytics'], $resolvedTier['hasAnalytics'], 'hasAnalytics matches');
+    assert_same($legacyTier['hasQRCodes'], $resolvedTier['hasQRCodes'], 'hasQRCodes matches');
+    assert_same($legacyTier['hasAPIAccess'], $resolvedTier['hasAPIAccess'], 'hasAPIAccess matches');
+    assert_same($legacyTier['hasPrioritySupport'], $resolvedTier['hasPrioritySupport'], 'hasPrioritySupport matches');
+    assert_same($legacyTier['hasCustomHTML'], $resolvedTier['hasCustomHTML'], 'hasCustomHTML matches');
+
+    g2ml_prbv_exec($db, "DELETE FROM `tblOrganisations` WHERE `orgHandle` = 'prbv-test-org'");
+
+    if (function_exists('g2ml_clearOrgTierCache'))
+    {
+        g2ml_clearOrgTierCache('prbv-test-org');
+    }
+
+    if (function_exists('g2ml_clearPricingCache'))
+    {
+        g2ml_clearPricingCache('prbv-test-org');
+    }
+});

--- a/tests/unit/pricing_resolver_test.php
+++ b/tests/unit/pricing_resolver_test.php
@@ -1,0 +1,817 @@
+<?php
+/**
+ * Copyright (c) 2024–2026 MWBM Partners Ltd (MWservices).
+ * All rights reserved.
+ *
+ * This source code is proprietary and confidential.
+ * Unauthorised copying, modification, or distribution is strictly prohibited.
+ */
+
+/**
+ * ============================================================================
+ * 🧪 Unit tests — flexible pricing/entitlement engine resolver (scaffold)
+ * ============================================================================
+ *
+ * Pure, DB-free tests for web/_functions/pricing.php AND the guarded hook it
+ * adds to web/_functions/entitlements.php's _g2ml_resolveOrgTier(). Every case
+ * that would otherwise touch the database drives the lookup-override seams:
+ *
+ *   - $GLOBALS['g2ml_entitlements_tier_lookup_override'] /
+ *     ['g2ml_entitlements_fallback_lookup_override']  (already defined by
+ *     entitlements.php — see tests/unit/entitlements_test.php)
+ *   - $GLOBALS['g2ml_pricing_features_override'] /
+ *     ['g2ml_pricing_tier_features_override'] /
+ *     ['g2ml_pricing_org_overrides_override']          (defined by pricing.php)
+ *
+ * Because every override intercepts BEFORE any real DB call, this file never
+ * requires db_connect.php/db_query.php and never needs a live database.
+ *
+ * ⚠️ settings.php is DELIBERATELY NOT required by this file (mirroring
+ * tests/unit/geolocation_test.php's own callout) and this file never defines
+ * a global getSetting() — doing so would leak into every OTHER unit test file
+ * sharing this single PHP process (tests/run.php requires every tests/unit/
+ * file into one execution) and was found, during development of this file, to
+ * break tests/unit/security_ssrf_host_guard_test.php's
+ * "settings unavailable (fail closed)" case, which asserts
+ * function_exists('getSetting') === false. Instead, pricing.php's
+ * _g2ml_pricingReadSetting() provides a dedicated test-only override seam
+ * ($GLOBALS['g2ml_pricing_setting_override']), driven here by
+ * $GLOBALS['g2ml_pr_unit_settings'], so g2ml_pricingEngineEnabled() and
+ * g2ml_pricingMeterUsage() can be tested deterministically without touching
+ * the global function table at all.
+ *
+ * The one path this file CANNOT cover is a genuine tblUsageCounters/
+ * tblUsageEvents DB write from g2ml_pricingMeterUsage() — that requires a real
+ * (or DB-overridden) connection and is left to integration testing, matching
+ * this codebase's convention that DB-touching behaviour is proven against a
+ * real schema instead of being faked (see tests/unit/entitlements_test.php's
+ * own header comment). What IS proven here is that a metering attempt with no
+ * DB layer loaded degrades gracefully (returns false, never throws).
+ *
+ * @package    Go2My.Link
+ * @subpackage Tests
+ * @since      v1.6.0 — Pricing Engine phase (scaffold)
+ * ============================================================================
+ */
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__, 2) . '/web/_functions/entitlements.php';
+require_once dirname(__DIR__, 2) . '/web/_functions/pricing.php';
+
+// ============================================================================
+// 🧰 Settings override — installs $GLOBALS['g2ml_pricing_setting_override']
+// (pricing.php's own test seam) backed by $GLOBALS['g2ml_pr_unit_settings'].
+// See header note above for why this file never defines getSetting() itself.
+// ============================================================================
+$GLOBALS['g2ml_pricing_setting_override'] = function (string $settingID, mixed $default): mixed
+{
+    if (isset($GLOBALS['g2ml_pr_unit_settings'])
+        && is_array($GLOBALS['g2ml_pr_unit_settings'])
+        && array_key_exists($settingID, $GLOBALS['g2ml_pr_unit_settings']))
+    {
+        return $GLOBALS['g2ml_pr_unit_settings'][$settingID];
+    }
+
+    return $default;
+};
+
+// ============================================================================
+// 🔧 Test helpers — reset, fixture builders, engine/metering toggles
+// ============================================================================
+
+/**
+ * Reset all pricing + entitlements test state between cases.
+ *
+ * @return void
+ */
+function g2ml_pr_unit_reset(): void
+{
+    g2ml_clearOrgTierCache();
+    g2ml_clearPricingCache();
+    unset($GLOBALS['g2ml_entitlements_tier_lookup_override']);
+    unset($GLOBALS['g2ml_entitlements_fallback_lookup_override']);
+    unset($GLOBALS['g2ml_pricing_features_override']);
+    unset($GLOBALS['g2ml_pricing_tier_features_override']);
+    unset($GLOBALS['g2ml_pricing_org_overrides_override']);
+    unset($GLOBALS['g2ml_pr_unit_settings']);
+    unset($GLOBALS['g2ml_pricing_engine_enabled_cache']);
+}
+
+/**
+ * Force the master pricing-engine switch on/off for the next resolution,
+ * bypassing the request cache so the change takes effect immediately.
+ *
+ * @param  bool $enabled
+ * @return void
+ */
+function g2ml_pr_unit_force_engine(bool $enabled): void
+{
+    if (!isset($GLOBALS['g2ml_pr_unit_settings']) || !is_array($GLOBALS['g2ml_pr_unit_settings']))
+    {
+        $GLOBALS['g2ml_pr_unit_settings'] = [];
+    }
+
+    if ($enabled === true)
+    {
+        $GLOBALS['g2ml_pr_unit_settings']['billing.pricing_engine_enabled'] = '1';
+    }
+    else
+    {
+        $GLOBALS['g2ml_pr_unit_settings']['billing.pricing_engine_enabled'] = '0';
+    }
+
+    unset($GLOBALS['g2ml_pricing_engine_enabled_cache']);
+}
+
+/**
+ * Force the usage-metering switch on/off.
+ *
+ * @param  bool $enabled
+ * @return void
+ */
+function g2ml_pr_unit_force_metering(bool $enabled): void
+{
+    if (!isset($GLOBALS['g2ml_pr_unit_settings']) || !is_array($GLOBALS['g2ml_pr_unit_settings']))
+    {
+        $GLOBALS['g2ml_pr_unit_settings'] = [];
+    }
+
+    if ($enabled === true)
+    {
+        $GLOBALS['g2ml_pr_unit_settings']['billing.usage_metering_enabled'] = '1';
+    }
+    else
+    {
+        $GLOBALS['g2ml_pr_unit_settings']['billing.usage_metering_enabled'] = '0';
+    }
+}
+
+/**
+ * Build one tblFeatures-shaped row.
+ *
+ * @param  int    $featureUID
+ * @param  string $slug
+ * @param  string $valueType
+ * @param  array  $overrides
+ * @return array
+ */
+function g2ml_pr_unit_feature_row(int $featureUID, string $slug, string $valueType, array $overrides = []): array
+{
+    $defaults = [
+        'featureUID'          => $featureUID,
+        'featureSlug'         => $slug,
+        'featureName'         => $slug,
+        'valueType'           => $valueType,
+        'valueUnit'           => null,
+        'quotaPeriod'         => null,
+        'defaultValueBoolean' => 0,
+        'defaultValueInt'     => 0,
+        'defaultValueString'  => null,
+        'defaultValueJSON'    => null,
+        'defaultIsUnlimited'  => 0,
+        'category'            => 'general',
+        'isMeterable'         => 0,
+        'legacyColumn'        => null,
+        'sortOrder'           => 0,
+    ];
+
+    return array_merge($defaults, $overrides);
+}
+
+/**
+ * The fixture feature registry used throughout this file — mirrors
+ * web/_sql/seeds/018_pricing_feature_registry.sql's legacy-mapped rows plus
+ * one granular non-legacy feature (redirects.geo) for the umbrella-rule test.
+ *
+ * @return array
+ */
+function g2ml_pr_unit_features(): array
+{
+    return [
+        g2ml_pr_unit_feature_row(1, 'links.max', 'limit', ['legacyColumn' => 'maxLinks', 'isMeterable' => 1]),
+        g2ml_pr_unit_feature_row(2, 'domains.custom_max', 'limit', ['legacyColumn' => 'maxCustomDomains']),
+        g2ml_pr_unit_feature_row(3, 'api.requests_per_day', 'quota', ['legacyColumn' => 'maxAPIRequestsPerDay', 'isMeterable' => 1]),
+        g2ml_pr_unit_feature_row(4, 'linkspage.pages_max', 'limit', ['legacyColumn' => 'maxLinksPages']),
+        g2ml_pr_unit_feature_row(5, 'redirects.advanced', 'boolean', ['legacyColumn' => 'hasAdvancedRedirects']),
+        g2ml_pr_unit_feature_row(6, 'analytics.enabled', 'boolean', ['legacyColumn' => 'hasAnalytics']),
+        g2ml_pr_unit_feature_row(7, 'qr.dynamic', 'boolean', ['legacyColumn' => 'hasQRCodes']),
+        g2ml_pr_unit_feature_row(8, 'api.access', 'boolean', ['legacyColumn' => 'hasAPIAccess']),
+        g2ml_pr_unit_feature_row(9, 'support.priority', 'boolean', ['legacyColumn' => 'hasPrioritySupport']),
+        g2ml_pr_unit_feature_row(10, 'linkspage.custom_html', 'boolean', ['legacyColumn' => 'hasCustomHTML']),
+        g2ml_pr_unit_feature_row(11, 'redirects.geo', 'boolean', []),
+    ];
+}
+
+/**
+ * Build one tblTierFeatures-shaped row.
+ *
+ * @param  int   $featureUID
+ * @param  array $overrides
+ * @return array
+ */
+function g2ml_pr_unit_tier_feature_row(int $featureUID, array $overrides = []): array
+{
+    $defaults = [
+        'tierFeatureUID' => 1,
+        'tierID'         => 'pr-unit-tier',
+        'featureUID'     => $featureUID,
+        'valueBoolean'   => null,
+        'valueInt'       => null,
+        'valueString'    => null,
+        'valueJSON'      => null,
+        'isUnlimited'    => 0,
+        'effectiveFrom'  => null,
+        'effectiveUntil' => null,
+    ];
+
+    return array_merge($defaults, $overrides);
+}
+
+/**
+ * Build one tblOrgFeatureOverrides-shaped row.
+ *
+ * @param  int    $overrideUID
+ * @param  int    $featureUID
+ * @param  string $mode
+ * @param  array  $overrides
+ * @return array
+ */
+function g2ml_pr_unit_org_override_row(int $overrideUID, int $featureUID, string $mode, array $overrides = []): array
+{
+    $defaults = [
+        'overrideUID'    => $overrideUID,
+        'orgHandle'      => 'pr-unit-org',
+        'featureUID'     => $featureUID,
+        'overrideMode'   => $mode,
+        'valueBoolean'   => null,
+        'valueInt'       => null,
+        'valueString'    => null,
+        'valueJSON'      => null,
+        'isUnlimited'    => 0,
+        'adjustDelta'    => null,
+        'effectiveFrom'  => null,
+        'effectiveUntil' => null,
+    ];
+
+    return array_merge($defaults, $overrides);
+}
+
+/**
+ * Build one legacy tblSubscriptionTiers-shaped row, as consumed by
+ * entitlements.php's _g2ml_fetchOrgTierRow()/_g2ml_fetchFallbackTierRow().
+ *
+ * @param  array $overrides
+ * @return array
+ */
+function g2ml_pr_unit_legacy_tier_row(array $overrides = []): array
+{
+    $defaults = [
+        'tierID'               => 'pr-unit-tier',
+        'tierName'             => 'Pricing Unit Test Tier',
+        'maxLinks'             => 10,
+        'maxCustomDomains'     => 2,
+        'maxAPIRequestsPerDay' => 1000,
+        'maxLinksPages'        => 3,
+        'hasAdvancedRedirects' => 0,
+        'hasAnalytics'         => 1,
+        'hasQRCodes'           => 1,
+        'hasAPIAccess'         => 0,
+        'hasPrioritySupport'   => 0,
+        'hasCustomHTML'        => 0,
+        'isActive'             => 1,
+    ];
+
+    return array_merge($defaults, $overrides);
+}
+
+/**
+ * Install the three pricing-fetch overrides in one call for convenience.
+ *
+ * @param  array $features
+ * @param  array $tierFeatures
+ * @param  array $orgOverrides
+ * @return void
+ */
+function g2ml_pr_unit_install_pricing_overrides(array $features, array $tierFeatures, array $orgOverrides): void
+{
+    $GLOBALS['g2ml_pricing_features_override'] = function () use ($features): array
+    {
+        return $features;
+    };
+
+    $GLOBALS['g2ml_pricing_tier_features_override'] = function (string $tierID) use ($tierFeatures): array
+    {
+        return $tierFeatures;
+    };
+
+    $GLOBALS['g2ml_pricing_org_overrides_override'] = function (string $orgHandle) use ($orgOverrides): array
+    {
+        return $orgOverrides;
+    };
+}
+
+// ============================================================================
+// 🔌 g2ml_pricingEngineEnabled() — reads getSetting(), request-cached
+// ============================================================================
+
+test('pricingEngineEnabled: reflects the master switch and is request-cached', function (): void
+{
+    g2ml_pr_unit_reset();
+
+    g2ml_pr_unit_force_engine(false);
+    assert_false(g2ml_pricingEngineEnabled(), 'OFF (0) reports disabled');
+
+    g2ml_pr_unit_force_engine(true);
+    assert_true(g2ml_pricingEngineEnabled(), 'ON (1) reports enabled');
+
+    // Change the underlying setting WITHOUT clearing the cache — the cached
+    // value must still be returned.
+    $GLOBALS['g2ml_pr_unit_settings']['billing.pricing_engine_enabled'] = '0';
+    assert_true(g2ml_pricingEngineEnabled(), 'Request-cached: a later setting change is not seen until the cache is cleared');
+
+    g2ml_clearPricingCache();
+    assert_false(g2ml_pricingEngineEnabled(), 'After clearing the cache, the new (now-disabled) value is seen');
+});
+
+// ============================================================================
+// 🚫 Hook OFF — entitlements.php ignores pricing.php entirely
+// ============================================================================
+
+test('hook OFF: g2ml_getOrgTier() resolves via the legacy path, unaffected by pricing.php being loaded', function (): void
+{
+    g2ml_pr_unit_reset();
+    g2ml_pr_unit_force_engine(false);
+
+    $GLOBALS['g2ml_entitlements_tier_lookup_override'] = function (string $orgHandle): array
+    {
+        return g2ml_pr_unit_legacy_tier_row(['tierID' => 'legacy-only']);
+    };
+
+    $tier = g2ml_getOrgTier('org-hook-off');
+
+    assert_same('tier', $tier['source'], 'Source is the legacy tier path, not pricing_engine');
+    assert_same(10, $tier['maxLinks'], 'Legacy maxLinks value is used, untouched by pricing.php');
+    assert_same('legacy-only', $tier['tierID']);
+});
+
+// ============================================================================
+// 🧩 g2ml_pricingResolveOrgTier() is flag-agnostic by design — only the
+// entitlements.php hook and the granular canUse()/getLimit() helpers gate on
+// the master switch; calling the resolver directly always attempts a full
+// resolution (this is what canUse()/getLimit() rely on once THEY have
+// already checked the flag themselves).
+// ============================================================================
+
+test('pricingResolveOrgTier: does not itself gate on the engine flag', function (): void
+{
+    g2ml_pr_unit_reset();
+    g2ml_pr_unit_force_engine(false);
+
+    $GLOBALS['g2ml_entitlements_tier_lookup_override'] = function (string $orgHandle): array
+    {
+        return g2ml_pr_unit_legacy_tier_row(['tierID' => 'engine-agnostic']);
+    };
+
+    g2ml_pr_unit_install_pricing_overrides(g2ml_pr_unit_features(), [], []);
+
+    $resolved = g2ml_pricingResolveOrgTier('org-direct-call');
+
+    assert_true(is_array($resolved), 'A direct call still resolves even though the engine flag is OFF');
+    assert_same('pricing_engine', $resolved['source']);
+});
+
+// ============================================================================
+// 🎯 Parity — legacy-shaped output matches the tier's configured values
+// ============================================================================
+
+test('pricingResolveOrgTier: legacy-shaped fields match the tier fixture through the merge (default -> tier)', function (): void
+{
+    g2ml_pr_unit_reset();
+
+    $GLOBALS['g2ml_entitlements_tier_lookup_override'] = function (string $orgHandle): array
+    {
+        return g2ml_pr_unit_legacy_tier_row(['tierID' => 'parity-tier']);
+    };
+
+    $tierFeatures = [
+        g2ml_pr_unit_tier_feature_row(1, ['valueInt' => 10]),
+        g2ml_pr_unit_tier_feature_row(2, ['valueInt' => 2]),
+        g2ml_pr_unit_tier_feature_row(3, ['valueInt' => 1000]),
+        g2ml_pr_unit_tier_feature_row(4, ['valueInt' => 3]),
+        g2ml_pr_unit_tier_feature_row(5, ['valueBoolean' => 0]),
+        g2ml_pr_unit_tier_feature_row(6, ['valueBoolean' => 1]),
+        g2ml_pr_unit_tier_feature_row(7, ['valueBoolean' => 1]),
+        g2ml_pr_unit_tier_feature_row(8, ['valueBoolean' => 0]),
+        g2ml_pr_unit_tier_feature_row(9, ['valueBoolean' => 0]),
+        g2ml_pr_unit_tier_feature_row(10, ['valueBoolean' => 0]),
+    ];
+
+    g2ml_pr_unit_install_pricing_overrides(g2ml_pr_unit_features(), $tierFeatures, []);
+
+    $resolved = g2ml_pricingResolveOrgTier('parity-org');
+
+    assert_same(10, $resolved['maxLinks']);
+    assert_same(2, $resolved['maxCustomDomains']);
+    assert_same(1000, $resolved['maxAPIRequestsPerDay']);
+    assert_same(3, $resolved['maxLinksPages']);
+    assert_false($resolved['hasAdvancedRedirects']);
+    assert_true($resolved['hasAnalytics']);
+    assert_true($resolved['hasQRCodes']);
+    assert_false($resolved['hasAPIAccess']);
+    assert_false($resolved['hasPrioritySupport']);
+    assert_false($resolved['hasCustomHTML']);
+    assert_false($resolved['unlimited']);
+    assert_same('pricing_engine', $resolved['source']);
+    assert_false($resolved['features']['redirects.geo'], 'A feature with no tier row falls back to its safe-floor default (false)');
+});
+
+// ============================================================================
+// 🔀 Merge order
+// ============================================================================
+
+test('merge order: the safe-floor default applies when the tier has no row for a feature', function (): void
+{
+    g2ml_pr_unit_reset();
+
+    $GLOBALS['g2ml_entitlements_tier_lookup_override'] = function (string $orgHandle): array
+    {
+        return g2ml_pr_unit_legacy_tier_row();
+    };
+
+    g2ml_pr_unit_install_pricing_overrides(g2ml_pr_unit_features(), [], []);
+
+    $resolved = g2ml_pricingResolveOrgTier('org-default-floor');
+
+    assert_same(0, $resolved['maxLinks'], 'links.max default (0) is used when the tier has no tblTierFeatures row');
+    assert_same(0, $resolved['features']['links.max']);
+});
+
+test('merge order: the tier value beats the default', function (): void
+{
+    g2ml_pr_unit_reset();
+
+    $GLOBALS['g2ml_entitlements_tier_lookup_override'] = function (string $orgHandle): array
+    {
+        return g2ml_pr_unit_legacy_tier_row();
+    };
+
+    $tierFeatures = [g2ml_pr_unit_tier_feature_row(1, ['valueInt' => 500])];
+    g2ml_pr_unit_install_pricing_overrides(g2ml_pr_unit_features(), $tierFeatures, []);
+
+    $resolved = g2ml_pricingResolveOrgTier('org-tier-beats-default');
+
+    assert_same(500, $resolved['maxLinks']);
+});
+
+test('merge order: deny beats a tier grant', function (): void
+{
+    g2ml_pr_unit_reset();
+
+    $GLOBALS['g2ml_entitlements_tier_lookup_override'] = function (string $orgHandle): array
+    {
+        return g2ml_pr_unit_legacy_tier_row();
+    };
+
+    $tierFeatures = [g2ml_pr_unit_tier_feature_row(6, ['valueBoolean' => 1])];
+    $orgOverrides = [g2ml_pr_unit_org_override_row(1, 6, 'deny')];
+
+    g2ml_pr_unit_install_pricing_overrides(g2ml_pr_unit_features(), $tierFeatures, $orgOverrides);
+
+    $resolved = g2ml_pricingResolveOrgTier('org-deny-beats-grant');
+
+    assert_false($resolved['hasAnalytics'], 'A deny override forces the feature off even though the tier grants it');
+    assert_false($resolved['features']['analytics.enabled']);
+});
+
+test('merge order: set replaces the value and isUnlimited', function (): void
+{
+    g2ml_pr_unit_reset();
+
+    $GLOBALS['g2ml_entitlements_tier_lookup_override'] = function (string $orgHandle): array
+    {
+        return g2ml_pr_unit_legacy_tier_row();
+    };
+
+    $tierFeatures = [
+        g2ml_pr_unit_tier_feature_row(1, ['valueInt' => 10]),
+        g2ml_pr_unit_tier_feature_row(2, ['valueInt' => 5]),
+    ];
+    $orgOverrides = [
+        g2ml_pr_unit_org_override_row(1, 1, 'set', ['valueInt' => 100000]),
+        g2ml_pr_unit_org_override_row(2, 2, 'set', ['isUnlimited' => 1]),
+    ];
+
+    g2ml_pr_unit_install_pricing_overrides(g2ml_pr_unit_features(), $tierFeatures, $orgOverrides);
+
+    $resolved = g2ml_pricingResolveOrgTier('org-set-replaces');
+
+    assert_same(100000, $resolved['maxLinks'], 'set replaces the tier value outright');
+    assert_same(null, $resolved['maxCustomDomains'], 'set with isUnlimited=1 maps to legacy NULL (unlimited)');
+});
+
+test('merge order: two adjust rows accumulate, and adjust floors at 0', function (): void
+{
+    g2ml_pr_unit_reset();
+
+    $GLOBALS['g2ml_entitlements_tier_lookup_override'] = function (string $orgHandle): array
+    {
+        return g2ml_pr_unit_legacy_tier_row();
+    };
+
+    $tierFeatures = [g2ml_pr_unit_tier_feature_row(2, ['valueInt' => 5])];
+    $orgOverrides = [
+        g2ml_pr_unit_org_override_row(1, 2, 'adjust', ['adjustDelta' => 5]),
+        g2ml_pr_unit_org_override_row(2, 2, 'adjust', ['adjustDelta' => 5]),
+    ];
+
+    g2ml_pr_unit_install_pricing_overrides(g2ml_pr_unit_features(), $tierFeatures, $orgOverrides);
+
+    $resolved = g2ml_pricingResolveOrgTier('org-adjust-accumulate');
+
+    assert_same(15, $resolved['maxCustomDomains'], 'Two +5 adjust rows accumulate on top of the tier value of 5');
+
+    g2ml_pr_unit_reset();
+
+    $GLOBALS['g2ml_entitlements_tier_lookup_override'] = function (string $orgHandle): array
+    {
+        return g2ml_pr_unit_legacy_tier_row();
+    };
+
+    $tierFeaturesFloor = [g2ml_pr_unit_tier_feature_row(2, ['valueInt' => 3])];
+    $orgOverridesFloor = [g2ml_pr_unit_org_override_row(1, 2, 'adjust', ['adjustDelta' => -10])];
+
+    g2ml_pr_unit_install_pricing_overrides(g2ml_pr_unit_features(), $tierFeaturesFloor, $orgOverridesFloor);
+
+    $resolvedFloor = g2ml_pricingResolveOrgTier('org-adjust-floor');
+
+    assert_same(0, $resolvedFloor['maxCustomDomains'], 'A large negative adjust never goes below 0');
+});
+
+// ============================================================================
+// 📅 Effective-dating: the latest-effectiveFrom-wins reduction
+// ============================================================================
+
+test('reduceLatestEffective: a dated row always beats an undated one, and the latest date wins among dated rows', function (): void
+{
+    $rows = [
+        ['featureUID' => 1, 'effectiveFrom' => null, 'value' => 'undated'],
+        ['featureUID' => 1, 'effectiveFrom' => '2026-01-01 00:00:00', 'value' => 'january'],
+        ['featureUID' => 1, 'effectiveFrom' => '2026-06-01 00:00:00', 'value' => 'june'],
+    ];
+
+    $winners = _g2ml_pricingReduceLatestEffective($rows);
+
+    assert_same('june', $winners['1']['value'], 'The latest-dated row wins over both the undated row and the earlier-dated row');
+
+    $rowsReordered = [
+        ['featureUID' => 2, 'effectiveFrom' => '2026-06-01 00:00:00', 'value' => 'june'],
+        ['featureUID' => 2, 'effectiveFrom' => null, 'value' => 'undated'],
+    ];
+
+    $winnersReordered = _g2ml_pricingReduceLatestEffective($rowsReordered);
+
+    assert_same('june', $winnersReordered['2']['value'], 'An undated row arriving AFTER a dated row still never displaces it');
+});
+
+// ============================================================================
+// ♾️ Unlimited mapping flows through entitlements.php's g2ml_checkLimit()
+// ============================================================================
+
+test('unlimited mapping: isUnlimited on a tier row maps to legacy NULL, and g2ml_checkLimit() reports unlimited', function (): void
+{
+    g2ml_pr_unit_reset();
+    g2ml_pr_unit_force_engine(true);
+
+    $GLOBALS['g2ml_entitlements_tier_lookup_override'] = function (string $orgHandle): array
+    {
+        return g2ml_pr_unit_legacy_tier_row(['tierID' => 'unlimited-parity']);
+    };
+
+    $tierFeatures = [g2ml_pr_unit_tier_feature_row(1, ['isUnlimited' => 1, 'valueInt' => null])];
+    g2ml_pr_unit_install_pricing_overrides(g2ml_pr_unit_features(), $tierFeatures, []);
+
+    $tier = g2ml_getOrgTier('unlimited-org');
+
+    assert_same(null, $tier['maxLinks'], 'isUnlimited=1 maps to legacy NULL');
+    assert_same('pricing_engine', $tier['source'], 'Precondition: the engine hook actually fired');
+
+    $check = g2ml_checkLimit('unlimited-org', 'maxLinks', 999999999);
+
+    assert_true($check['allowed'], 'g2ml_checkLimit() reads the pricing-engine-produced NULL as unlimited');
+    assert_same(null, $check['limit']);
+});
+
+// ============================================================================
+// ☂️ Umbrella rule
+// ============================================================================
+
+test('umbrella rule: any granular redirects.* flag true forces hasAdvancedRedirects true', function (): void
+{
+    g2ml_pr_unit_reset();
+
+    $GLOBALS['g2ml_entitlements_tier_lookup_override'] = function (string $orgHandle): array
+    {
+        return g2ml_pr_unit_legacy_tier_row();
+    };
+
+    $tierFeatures = [
+        g2ml_pr_unit_tier_feature_row(5, ['valueBoolean' => 0]),
+        g2ml_pr_unit_tier_feature_row(11, ['valueBoolean' => 1]),
+    ];
+
+    g2ml_pr_unit_install_pricing_overrides(g2ml_pr_unit_features(), $tierFeatures, []);
+
+    $resolved = g2ml_pricingResolveOrgTier('org-umbrella');
+
+    assert_true($resolved['hasAdvancedRedirects'], 'The granular redirects.geo=true forces the umbrella flag true even though the umbrella row itself is off');
+    assert_true($resolved['features']['redirects.geo']);
+});
+
+// ============================================================================
+// 🛡️ Fail-open
+// ============================================================================
+
+test('fail-open: a pricing-fetch failure falls back to the legacy path via the entitlements.php hook', function (): void
+{
+    g2ml_pr_unit_reset();
+    g2ml_pr_unit_force_engine(true);
+
+    $GLOBALS['g2ml_entitlements_tier_lookup_override'] = function (string $orgHandle): array
+    {
+        return g2ml_pr_unit_legacy_tier_row(['tierID' => 'fail-open-features']);
+    };
+
+    $GLOBALS['g2ml_pricing_features_override'] = function (): bool
+    {
+        return false;
+    };
+
+    $tier = g2ml_getOrgTier('fail-open-org');
+
+    assert_same('tier', $tier['source'], 'The pricing engine failed internally, so entitlements.php fell back to the legacy tier resolution');
+    assert_same(10, $tier['maxLinks']);
+});
+
+test('fail-open: a shared org/tier lookup failure yields the unlimited sentinel regardless of the engine flag', function (): void
+{
+    g2ml_pr_unit_reset();
+    g2ml_pr_unit_force_engine(true);
+
+    $GLOBALS['g2ml_entitlements_tier_lookup_override'] = function (string $orgHandle): bool
+    {
+        return false;
+    };
+
+    $tier = g2ml_getOrgTier('outage-org');
+
+    assert_true($tier['unlimited'], 'A system failure resolving the org/tier row fails OPEN regardless of the pricing-engine flag');
+    assert_same('fail_open_lookup_error', $tier['source']);
+});
+
+// ============================================================================
+// 🚩 g2ml_pricingCanUse()
+// ============================================================================
+
+test('pricingCanUse: an unrecognised slug is denied; engine OFF denies even a real slug', function (): void
+{
+    g2ml_pr_unit_reset();
+    g2ml_pr_unit_force_engine(true);
+
+    $GLOBALS['g2ml_entitlements_tier_lookup_override'] = function (string $orgHandle): array
+    {
+        return g2ml_pr_unit_legacy_tier_row();
+    };
+
+    $tierFeatures = [
+        g2ml_pr_unit_tier_feature_row(6, ['valueBoolean' => 1]),
+        g2ml_pr_unit_tier_feature_row(8, ['valueBoolean' => 0]),
+    ];
+    g2ml_pr_unit_install_pricing_overrides(g2ml_pr_unit_features(), $tierFeatures, []);
+
+    assert_false(g2ml_pricingCanUse('org-can-use', 'not.a.real.slug'), 'An unrecognised slug is denied');
+    assert_true(g2ml_pricingCanUse('org-can-use', 'analytics.enabled'), 'A granted feature reflects true');
+    assert_false(g2ml_pricingCanUse('org-can-use', 'api.access'), 'A denied/default feature reflects false');
+
+    g2ml_pr_unit_force_engine(false);
+    assert_false(g2ml_pricingCanUse('org-can-use', 'analytics.enabled'), 'Engine OFF always denies, regardless of the underlying data');
+});
+
+test('pricingCanUse: a resolution failure denies (engine ON, resolver fails internally)', function (): void
+{
+    g2ml_pr_unit_reset();
+    g2ml_pr_unit_force_engine(true);
+
+    $GLOBALS['g2ml_entitlements_tier_lookup_override'] = function (string $orgHandle): array
+    {
+        return g2ml_pr_unit_legacy_tier_row();
+    };
+
+    $GLOBALS['g2ml_pricing_features_override'] = function (): bool
+    {
+        return false;
+    };
+
+    assert_false(g2ml_pricingCanUse('org-can-use-fail', 'analytics.enabled'));
+});
+
+// ============================================================================
+// 🔢 g2ml_pricingGetLimit()
+// ============================================================================
+
+test('pricingGetLimit: an unrecognised slug fails OPEN; a real limit computes correctly; engine OFF fails OPEN', function (): void
+{
+    g2ml_pr_unit_reset();
+    g2ml_pr_unit_force_engine(true);
+
+    $GLOBALS['g2ml_entitlements_tier_lookup_override'] = function (string $orgHandle): array
+    {
+        return g2ml_pr_unit_legacy_tier_row();
+    };
+
+    $tierFeatures = [g2ml_pr_unit_tier_feature_row(1, ['valueInt' => 5])];
+    g2ml_pr_unit_install_pricing_overrides(g2ml_pr_unit_features(), $tierFeatures, []);
+
+    $unknown = g2ml_pricingGetLimit('org-get-limit', 'not.a.real.limit', 999999);
+    assert_true($unknown['allowed'], 'An unrecognised slug fails OPEN');
+    assert_same(null, $unknown['limit']);
+
+    $under = g2ml_pricingGetLimit('org-get-limit', 'links.max', 3);
+    assert_true($under['allowed']);
+    assert_same(5, $under['limit']);
+    assert_same(2, $under['remaining']);
+
+    $over = g2ml_pricingGetLimit('org-get-limit', 'links.max', 10);
+    assert_false($over['allowed']);
+    assert_same(0, $over['remaining']);
+
+    g2ml_pr_unit_force_engine(false);
+    $engineOff = g2ml_pricingGetLimit('org-get-limit', 'links.max', 999999999);
+    assert_true($engineOff['allowed'], 'Engine OFF fails OPEN regardless of the underlying data');
+    assert_same(null, $engineOff['limit']);
+});
+
+test('pricingGetLimit: a resolution failure fails OPEN (engine ON, resolver fails internally)', function (): void
+{
+    g2ml_pr_unit_reset();
+    g2ml_pr_unit_force_engine(true);
+
+    $GLOBALS['g2ml_entitlements_tier_lookup_override'] = function (string $orgHandle): array
+    {
+        return g2ml_pr_unit_legacy_tier_row();
+    };
+
+    $GLOBALS['g2ml_pricing_features_override'] = function (): bool
+    {
+        return false;
+    };
+
+    $result = g2ml_pricingGetLimit('org-get-limit-fail', 'links.max', 999999999);
+
+    assert_true($result['allowed']);
+    assert_same(null, $result['limit']);
+});
+
+// ============================================================================
+// 📊 g2ml_pricingMeterUsage()
+// ============================================================================
+
+test('pricingMeterUsage: metering OFF is a no-op that returns true', function (): void
+{
+    g2ml_pr_unit_reset();
+    g2ml_pr_unit_force_metering(false);
+
+    assert_true(g2ml_pricingMeterUsage('org-meter-off', 'links.max', 1));
+});
+
+test('pricingMeterUsage: metering ON with an unrecognised or non-meterable slug returns false', function (): void
+{
+    g2ml_pr_unit_reset();
+    g2ml_pr_unit_force_metering(true);
+
+    $GLOBALS['g2ml_pricing_features_override'] = function (): array
+    {
+        return g2ml_pr_unit_features();
+    };
+
+    assert_false(g2ml_pricingMeterUsage('org-meter-unknown', 'not.a.real.slug'), 'An unrecognised feature slug is never metered');
+    assert_false(g2ml_pricingMeterUsage('org-meter-non-meterable', 'support.priority'), 'A feature with isMeterable=0 is never metered');
+});
+
+test('pricingMeterUsage: metering ON for a real meterable feature degrades gracefully with no DB layer loaded (never throws)', function (): void
+{
+    g2ml_pr_unit_reset();
+    g2ml_pr_unit_force_metering(true);
+
+    $GLOBALS['g2ml_pricing_features_override'] = function (): array
+    {
+        return g2ml_pr_unit_features();
+    };
+
+    // db_query.php's dbInsert() is deliberately NOT loaded in this DB-free
+    // unit file, so the attempt fails internally (caught by
+    // g2ml_pricingMeterUsage()'s own try/catch) and returns false rather than
+    // throwing — proving the fail-safe wrapper. The actual DB write is
+    // covered by integration testing.
+    assert_false(g2ml_pricingMeterUsage('org-meter-real', 'links.max', 1));
+});

--- a/web/_functions/entitlements.php
+++ b/web/_functions/entitlements.php
@@ -308,6 +308,29 @@ function _g2ml_resolveOrgTier(string $orgHandle): array
             return _g2ml_entitlementsUnlimitedTier('globaladmin');
         }
 
+        // -------------------------------------------------------------------
+        // 💷 OPTIONAL pricing-engine hook: when web/_functions/pricing.php is
+        // loaded AND the operator has switched 'billing.pricing_engine_enabled'
+        // ON, resolve entitlements from the flexible model instead. Any failure
+        // (false/non-array) falls through to the legacy resolution below —
+        // fail OPEN to OLD behaviour, never to a block. With the setting at
+        // its seeded '0' this block is inert and the function behaves exactly
+        // as before (see web/_sql/seeds/019_pricing_settings.sql).
+        // -------------------------------------------------------------------
+        if (function_exists('g2ml_pricingEngineEnabled')
+            && function_exists('g2ml_pricingResolveOrgTier'))
+        {
+            if (g2ml_pricingEngineEnabled() === true)
+            {
+                $engineTier = g2ml_pricingResolveOrgTier($orgHandle);
+
+                if (is_array($engineTier))
+                {
+                    return $engineTier;
+                }
+            }
+        }
+
         $row = _g2ml_fetchOrgTierRow($orgHandle);
 
         if ($row === false)

--- a/web/_functions/pricing.php
+++ b/web/_functions/pricing.php
@@ -1,0 +1,1105 @@
+<?php
+/**
+ * Copyright (c) 2024–2026 MWBM Partners Ltd (MWservices).
+ * All rights reserved.
+ *
+ * This source code is proprietary and confidential.
+ * Unauthorised copying, modification, or distribution is strictly prohibited.
+ */
+
+/**
+ * ============================================================================
+ * 💷 Go2My.Link — Flexible Pricing & Entitlement Engine Resolver (scaffold)
+ * ============================================================================
+ *
+ * Data-driven replacement for the HARD-CODED tblSubscriptionTiers has* and
+ * max* columns, built on top of web/_sql/schema/036_pricing_engine.sql. This file
+ * is DISABLED BY DEFAULT: every public function first checks
+ * g2ml_pricingEngineEnabled(), which reads tblSettings
+ * 'billing.pricing_engine_enabled' — seeded '0' by
+ * web/_sql/seeds/019_pricing_settings.sql. While that setting is '0', this
+ * file is loaded (see web/_includes/page_init.php) but produces NO output
+ * that anything reads: the single guarded hook in
+ * web/_functions/entitlements.php's _g2ml_resolveOrgTier() only calls into
+ * this file when the flag is '1', so entitlements.php's behaviour is
+ * byte-for-byte unchanged until an operator flips that switch.
+ *
+ * Like entitlements.php, this file only DEFINES functions/constants at
+ * include time — no top-level side effects, no queries run merely by
+ * requiring it — so it is safe to require standalone (tests do exactly
+ * that).
+ *
+ * PUBLIC API PRESERVED: this file NEVER changes the signatures or behaviour
+ * of entitlements.php's g2ml_getOrgTier(), g2ml_canUseFeature(),
+ * g2ml_checkLimit(), or their two whitelist constants. It offers a SEPARATE,
+ * ADDITIVE set of functions for new call sites once the engine is live:
+ *
+ *   - g2ml_pricingEngineEnabled()    — is the master switch on? (request-cached)
+ *   - g2ml_pricingResolveOrgTier()   — the legacy-shaped resolver entitlements.php
+ *                                      hooks into (plus a 'features' sub-array
+ *                                      of every granular slug for new callers)
+ *   - g2ml_pricingCanUse()           — granular boolean feature check
+ *   - g2ml_pricingGetLimit()         — granular limit/quota check
+ *   - g2ml_pricingMeterUsage()       — records metered usage (no-op unless
+ *                                      billing.usage_metering_enabled='1')
+ *   - g2ml_clearPricingCache()       — invalidate this file's request caches
+ *
+ * FAIL-OPEN CONTRACT (non-negotiable, mirrors entitlements.php): every DB
+ * read here is guarded so a query/system failure resolves to `false`
+ * (resolver) or an "allowed"/no-op result (granular checks/metering) rather
+ * than throwing or blocking a legitimate action. g2ml_pricingResolveOrgTier()
+ * returning anything other than an array tells the caller (entitlements.php)
+ * to fall through to the LEGACY resolution path, which itself fails open to
+ * the unlimited sentinel — so a bug in this file can never newly block
+ * create/redirect/login.
+ *
+ * MERGE ORDER (safe-floor default → tier value → org override):
+ *   1. tblFeatures.default* — the safe floor used when a tier has no row at
+ *      all for a feature (defaults are "off"/0/not-unlimited, so a forgotten
+ *      mapping can never accidentally grant a premium capability).
+ *   2. tblTierFeatures — the tier's own currently-effective value (latest
+ *      effectiveFrom <= NOW(), effectiveUntil NULL or > NOW()).
+ *   3. tblOrgFeatureOverrides — applied IN overrideUID ORDER so multiple
+ *      'adjust' rows accumulate deterministically: 'deny' forces off,
+ *      'grant' forces on, 'set' replaces the value (incl. isUnlimited),
+ *      'adjust' adds adjustDelta to the numeric value, floored at 0.
+ *
+ * Dependencies: db_query.php (dbSelect/dbInsert), settings.php (getSetting) —
+ * both loaded earlier in page_init.php's Layer 2. Also REUSES (at CALL time,
+ * not include time) entitlements.php's private org→tier fetchers
+ * (_g2ml_fetchOrgTierRow()/_g2ml_fetchFallbackTierRow()) so org/tier/
+ * fallback/GlobalAdmin resolution semantics stay byte-identical between the
+ * legacy and pricing-engine paths — including their test-only lookup-override
+ * globals. page_init.php loads this file immediately BEFORE entitlements.php,
+ * but that only affects include ORDER, not availability: by the time any
+ * caller actually INVOKES g2ml_pricingResolveOrgTier(), page_init.php has
+ * finished requiring both files, so both function sets already exist.
+ *
+ * @package    Go2My.Link
+ * @subpackage Functions
+ * @author     MWBM Partners Ltd (MWservices)
+ * @version    1.0.0
+ * @since      v1.6.0 — Pricing Engine phase (scaffold — inert until
+ *             billing.pricing_engine_enabled is switched on)
+ *
+ * 📖 References:
+ *     - Tables:               web/_sql/schema/036_pricing_engine.sql
+ *     - Feature/backfill seed: web/_sql/seeds/018_pricing_feature_registry.sql
+ *     - Engine-switch seed:   web/_sql/seeds/019_pricing_settings.sql
+ *     - Legacy API preserved: web/_functions/entitlements.php
+ *     - Guarded hook:         entitlements.php's _g2ml_resolveOrgTier()
+ * ============================================================================
+ */
+
+// ============================================================================
+// 🛡️ Direct Access Guard
+// ============================================================================
+if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__))
+{
+    header('Location: https://go2my.link');
+    exit;
+}
+
+// ============================================================================
+// 🔑 Constants
+// ============================================================================
+if (!defined('G2ML_PRICING_SETTING_MASTER'))
+{
+    define('G2ML_PRICING_SETTING_MASTER', 'billing.pricing_engine_enabled');
+}
+
+// ============================================================================
+// 🗄️ Test-only lookup overrides — mirror entitlements.php's
+// $GLOBALS['g2ml_entitlements_tier_lookup_override'] idiom. Each override, when
+// set to a callable, is checked BEFORE the real DB call, so tests never touch
+// a live database. Unset in normal runtime.
+// ============================================================================
+
+/**
+ * Fetch every ACTIVE tblFeatures row (request-cached by the caller).
+ *
+ * Test-only override: set $GLOBALS['g2ml_pricing_features_override'] to a
+ * callable of shape `(): array|false` to simulate a result — including a
+ * system failure (`false`) — deterministically.
+ *
+ * @return array|false  List of feature rows, or false on a DB/query system error.
+ */
+function _g2ml_pricingFetchFeatures(): array|false
+{
+    if (isset($GLOBALS['g2ml_pricing_features_override'])
+        && is_callable($GLOBALS['g2ml_pricing_features_override']))
+    {
+        $override = $GLOBALS['g2ml_pricing_features_override'];
+
+        return $override();
+    }
+
+    return dbSelect(
+        "SELECT featureUID, featureSlug, featureName, valueType, valueUnit, quotaPeriod,
+                defaultValueBoolean, defaultValueInt, defaultValueString, defaultValueJSON,
+                defaultIsUnlimited, category, isMeterable, legacyColumn, sortOrder
+         FROM tblFeatures
+         WHERE isActive = 1
+         ORDER BY sortOrder ASC",
+        '',
+        []
+    );
+}
+
+/**
+ * Fetch every tblTierFeatures row for a tier (effective-dating is applied by
+ * the WHERE clause; picking the LATEST effectiveFrom per feature is done by
+ * the caller in PHP — see _g2ml_pricingReduceLatestEffective()).
+ *
+ * Test-only override: set $GLOBALS['g2ml_pricing_tier_features_override'] to a
+ * callable of shape `(string $tierID): array|false`.
+ *
+ * @param  string $tierID
+ * @return array|false  List of currently-effective tier-feature rows, or
+ *                        false on a DB/query system error.
+ */
+function _g2ml_pricingFetchTierFeatures(string $tierID): array|false
+{
+    if (isset($GLOBALS['g2ml_pricing_tier_features_override'])
+        && is_callable($GLOBALS['g2ml_pricing_tier_features_override']))
+    {
+        $override = $GLOBALS['g2ml_pricing_tier_features_override'];
+
+        return $override($tierID);
+    }
+
+    return dbSelect(
+        "SELECT tierFeatureUID, tierID, featureUID, valueBoolean, valueInt, valueString, valueJSON,
+                isUnlimited, effectiveFrom, effectiveUntil
+         FROM tblTierFeatures
+         WHERE tierID = ?
+           AND (effectiveFrom IS NULL OR effectiveFrom <= NOW())
+           AND (effectiveUntil IS NULL OR effectiveUntil > NOW())",
+        's',
+        [$tierID]
+    );
+}
+
+/**
+ * Fetch every ACTIVE, currently-effective tblOrgFeatureOverrides row for an
+ * org, ordered by overrideUID so multiple 'adjust' rows accumulate
+ * deterministically.
+ *
+ * Test-only override: set $GLOBALS['g2ml_pricing_org_overrides_override'] to a
+ * callable of shape `(string $orgHandle): array|false`.
+ *
+ * @param  string $orgHandle
+ * @return array|false  List of override rows in overrideUID order, or false
+ *                        on a DB/query system error.
+ */
+function _g2ml_pricingFetchOrgOverrides(string $orgHandle): array|false
+{
+    if (isset($GLOBALS['g2ml_pricing_org_overrides_override'])
+        && is_callable($GLOBALS['g2ml_pricing_org_overrides_override']))
+    {
+        $override = $GLOBALS['g2ml_pricing_org_overrides_override'];
+
+        return $override($orgHandle);
+    }
+
+    return dbSelect(
+        "SELECT overrideUID, orgHandle, featureUID, overrideMode, valueBoolean, valueInt,
+                valueString, valueJSON, isUnlimited, adjustDelta, effectiveFrom, effectiveUntil
+         FROM tblOrgFeatureOverrides
+         WHERE orgHandle = ?
+           AND isActive = 1
+           AND (effectiveFrom IS NULL OR effectiveFrom <= NOW())
+           AND (effectiveUntil IS NULL OR effectiveUntil > NOW())
+         ORDER BY overrideUID ASC",
+        's',
+        [$orgHandle]
+    );
+}
+
+// ============================================================================
+// 🔧 Internal helpers — merge maths, JSON decoding, request caches
+// ============================================================================
+
+/**
+ * Read one tblSettings value through getSetting(), with a test-only override
+ * seam — mirrors the fetch-override idiom above so tests can drive
+ * engine/metering switches deterministically without loading settings.php
+ * (and without redefining the global getSetting() function itself, which
+ * would leak into every other unit test file sharing this process).
+ *
+ * Test-only override: set $GLOBALS['g2ml_pricing_setting_override'] to a
+ * callable of shape `(string $settingID, mixed $default): mixed`.
+ *
+ * @param  string $settingID
+ * @param  mixed  $default
+ * @return mixed
+ */
+function _g2ml_pricingReadSetting(string $settingID, mixed $default): mixed
+{
+    if (isset($GLOBALS['g2ml_pricing_setting_override'])
+        && is_callable($GLOBALS['g2ml_pricing_setting_override']))
+    {
+        $override = $GLOBALS['g2ml_pricing_setting_override'];
+
+        return $override($settingID, $default);
+    }
+
+    if (function_exists('getSetting'))
+    {
+        return getSetting($settingID, $default);
+    }
+
+    return $default;
+}
+
+/**
+ * Decode a JSON column value that may already be an array (test fixtures),
+ * a JSON string (real DB rows), or null. Invalid JSON degrades to null
+ * (logged) rather than throwing.
+ *
+ * @param  mixed $rawValue
+ * @return mixed  The decoded value (array/scalar), or null.
+ */
+function _g2ml_pricingDecodeJSON(mixed $rawValue): mixed
+{
+    if ($rawValue === null)
+    {
+        return null;
+    }
+
+    if (is_array($rawValue))
+    {
+        return $rawValue;
+    }
+
+    if (!is_string($rawValue) || $rawValue === '')
+    {
+        return null;
+    }
+
+    $decoded = json_decode($rawValue, true);
+
+    if (json_last_error() !== JSON_ERROR_NONE)
+    {
+        error_log('[Go2My.Link] WARNING: pricing — invalid JSON value encountered during resolution: ' . json_last_error_msg());
+
+        return null;
+    }
+
+    return $decoded;
+}
+
+/**
+ * Reduce a list of currently-effective tblTierFeatures rows to one row per
+ * featureUID — the row with the LATEST effectiveFrom (NULL = oldest, so a
+ * dated row always wins over an undated one).
+ *
+ * @param  array $tierFeatureRows
+ * @return array  Keyed by featureUID (as a string) => the winning row.
+ */
+function _g2ml_pricingReduceLatestEffective(array $tierFeatureRows): array
+{
+    $winners = [];
+
+    foreach ($tierFeatureRows as $row)
+    {
+        $featureUIDKey = (string) $row['featureUID'];
+
+        if (!isset($winners[$featureUIDKey]))
+        {
+            $winners[$featureUIDKey] = $row;
+            continue;
+        }
+
+        $candidateEffectiveFrom = $row['effectiveFrom'] ?? null;
+        $currentEffectiveFrom   = $winners[$featureUIDKey]['effectiveFrom'] ?? null;
+
+        if ($candidateEffectiveFrom === null)
+        {
+            // An undated row never beats an already-stored row (NULL = oldest).
+            continue;
+        }
+
+        if ($currentEffectiveFrom === null)
+        {
+            $winners[$featureUIDKey] = $row;
+            continue;
+        }
+
+        if (strtotime($candidateEffectiveFrom) > strtotime($currentEffectiveFrom))
+        {
+            $winners[$featureUIDKey] = $row;
+        }
+    }
+
+    return $winners;
+}
+
+/**
+ * Resolve one feature's final value by applying the merge order (default →
+ * tier → ordered org overrides) for the feature's own valueType.
+ *
+ * @param  array      $featureRow       The tblFeatures row (defaults, valueType).
+ * @param  array|null $tierFeatureRow   The tier's winning tblTierFeatures row, or null.
+ * @param  array      $orgOverrideRows  This feature's tblOrgFeatureOverrides rows, in overrideUID order.
+ * @return array{valueType: string, value: mixed, isUnlimited: bool}
+ */
+function _g2ml_pricingResolveFeatureValue(array $featureRow, ?array $tierFeatureRow, array $orgOverrideRows): array
+{
+    $valueType   = (string) $featureRow['valueType'];
+    $isUnlimited = false;
+    $value       = null;
+
+    // -------------------------------------------------------------------
+    // 1. Safe-floor default.
+    // -------------------------------------------------------------------
+    if ($valueType === 'boolean')
+    {
+        $value = ((int) ($featureRow['defaultValueBoolean'] ?? 0) === 1);
+    }
+    elseif ($valueType === 'limit' || $valueType === 'quota')
+    {
+        $isUnlimited = ((int) ($featureRow['defaultIsUnlimited'] ?? 0) === 1);
+
+        if ($isUnlimited === true)
+        {
+            $value = null;
+        }
+        elseif ($featureRow['defaultValueInt'] !== null)
+        {
+            $value = (int) $featureRow['defaultValueInt'];
+        }
+        else
+        {
+            $value = null;
+        }
+    }
+    elseif ($valueType === 'enum')
+    {
+        $value = $featureRow['defaultValueString'] ?? null;
+    }
+    else
+    {
+        // 'config'
+        $value = _g2ml_pricingDecodeJSON($featureRow['defaultValueJSON'] ?? null);
+    }
+
+    // -------------------------------------------------------------------
+    // 2. Tier value (when the tier has its own currently-effective row).
+    // -------------------------------------------------------------------
+    if ($tierFeatureRow !== null)
+    {
+        if ($valueType === 'boolean')
+        {
+            $value = ((int) ($tierFeatureRow['valueBoolean'] ?? 0) === 1);
+        }
+        elseif ($valueType === 'limit' || $valueType === 'quota')
+        {
+            $isUnlimited = ((int) ($tierFeatureRow['isUnlimited'] ?? 0) === 1);
+
+            if ($isUnlimited === true)
+            {
+                $value = null;
+            }
+            elseif ($tierFeatureRow['valueInt'] !== null)
+            {
+                $value = (int) $tierFeatureRow['valueInt'];
+            }
+            else
+            {
+                $value = null;
+            }
+        }
+        elseif ($valueType === 'enum')
+        {
+            $value = $tierFeatureRow['valueString'] ?? null;
+        }
+        else
+        {
+            $value = _g2ml_pricingDecodeJSON($tierFeatureRow['valueJSON'] ?? null);
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // 3. Org overrides, applied in overrideUID order.
+    // -------------------------------------------------------------------
+    foreach ($orgOverrideRows as $overrideRow)
+    {
+        $mode = (string) ($overrideRow['overrideMode'] ?? 'set');
+
+        if ($mode === 'deny')
+        {
+            if ($valueType === 'boolean')
+            {
+                $value = false;
+            }
+            elseif ($valueType === 'limit' || $valueType === 'quota')
+            {
+                $isUnlimited = false;
+                $value       = 0;
+            }
+            else
+            {
+                $value = null;
+            }
+
+            continue;
+        }
+
+        if ($mode === 'grant')
+        {
+            if ($valueType === 'boolean')
+            {
+                $value = true;
+            }
+            elseif ($valueType === 'limit' || $valueType === 'quota')
+            {
+                $isUnlimited = true;
+                $value       = null;
+            }
+
+            continue;
+        }
+
+        if ($mode === 'set')
+        {
+            if ($valueType === 'boolean')
+            {
+                $value = ((int) ($overrideRow['valueBoolean'] ?? 0) === 1);
+            }
+            elseif ($valueType === 'limit' || $valueType === 'quota')
+            {
+                $isUnlimited = ((int) ($overrideRow['isUnlimited'] ?? 0) === 1);
+
+                if ($isUnlimited === true)
+                {
+                    $value = null;
+                }
+                elseif ($overrideRow['valueInt'] !== null)
+                {
+                    $value = (int) $overrideRow['valueInt'];
+                }
+                else
+                {
+                    $value = null;
+                }
+            }
+            elseif ($valueType === 'enum')
+            {
+                $value = $overrideRow['valueString'] ?? null;
+            }
+            else
+            {
+                $value = _g2ml_pricingDecodeJSON($overrideRow['valueJSON'] ?? null);
+            }
+
+            continue;
+        }
+
+        if ($mode === 'adjust')
+        {
+            if (($valueType === 'limit' || $valueType === 'quota') && $isUnlimited === false)
+            {
+                $delta        = (int) ($overrideRow['adjustDelta'] ?? 0);
+                $currentValue = 0;
+
+                if ($value !== null)
+                {
+                    $currentValue = (int) $value;
+                }
+
+                $adjustedValue = $currentValue + $delta;
+
+                if ($adjustedValue < 0)
+                {
+                    $adjustedValue = 0;
+                }
+
+                $value = $adjustedValue;
+            }
+
+            continue;
+        }
+    }
+
+    return [
+        'valueType'   => $valueType,
+        'value'       => $value,
+        'isUnlimited' => $isUnlimited,
+    ];
+}
+
+// ============================================================================
+// 🌐 Public API
+// ============================================================================
+
+/**
+ * Is the flexible pricing engine's MASTER switch on?
+ *
+ * Reads tblSettings 'billing.pricing_engine_enabled' via getSetting()
+ * (through _g2ml_pricingReadSetting()), which is seeded '0' by
+ * web/_sql/seeds/019_pricing_settings.sql — so this returns false on every
+ * install until an operator explicitly flips it. Request-cached so repeated
+ * calls within one request never re-hit the settings cache.
+ *
+ * @return bool
+ */
+function g2ml_pricingEngineEnabled(): bool
+{
+    if (isset($GLOBALS['g2ml_pricing_engine_enabled_cache'])
+        && is_bool($GLOBALS['g2ml_pricing_engine_enabled_cache']))
+    {
+        return $GLOBALS['g2ml_pricing_engine_enabled_cache'];
+    }
+
+    $enabled = false;
+
+    try
+    {
+        $enabled = (_g2ml_pricingReadSetting(G2ML_PRICING_SETTING_MASTER, '0') === '1');
+    }
+    catch (Throwable $unexpectedError)
+    {
+        error_log('[Go2My.Link] ERROR: pricing — unexpected exception reading the master switch: ' . $unexpectedError->getMessage() . ' — treating the engine as OFF.');
+        $enabled = false;
+    }
+
+    $GLOBALS['g2ml_pricing_engine_enabled_cache'] = $enabled;
+
+    return $enabled;
+}
+
+/**
+ * Resolve an organisation's effective entitlement tier via the flexible
+ * pricing engine, emitted in the SAME legacy shape entitlements.php's
+ * _g2ml_entitlementsNormaliseTierRow() produces (tierID, tierName, max*
+ * limits, has* flags, unlimited, source), PLUS a 'features' sub-array keyed
+ * by every ACTIVE feature slug for new granular callers.
+ *
+ * Does NOT itself check g2ml_pricingEngineEnabled() — the caller
+ * (entitlements.php's guarded hook) already does that; this function always
+ * attempts a full resolution when called directly, which is what the unit
+ * tests and g2ml_pricingCanUse()/g2ml_pricingGetLimit() need.
+ *
+ * FAIL-OPEN: any DB/system error at any step returns false so the caller
+ * falls back to the legacy resolver (which itself fails open to the
+ * unlimited sentinel) — this function must never throw.
+ *
+ * @param  string $orgHandle
+ * @return array|false
+ */
+function g2ml_pricingResolveOrgTier(string $orgHandle): array|false
+{
+    try
+    {
+        if (!function_exists('_g2ml_fetchOrgTierRow') || !function_exists('_g2ml_fetchFallbackTierRow'))
+        {
+            error_log('[Go2My.Link] ERROR: pricing — entitlements.php helpers are unavailable; cannot resolve org "' . $orgHandle . '" — falling back to legacy resolution.');
+
+            return false;
+        }
+
+        // ---------------------------------------------------------------
+        // 1. Resolve org → tierID (identical semantics to the legacy path,
+        //    including the lowest-sortOrder ACTIVE fallback).
+        // ---------------------------------------------------------------
+        $tierRow = _g2ml_fetchOrgTierRow($orgHandle);
+
+        if ($tierRow === false)
+        {
+            error_log('[Go2My.Link] ERROR: pricing — org tier lookup failed for org "' . $orgHandle . '" — falling back to legacy resolution.');
+
+            return false;
+        }
+
+        if ($tierRow !== null && (int) ($tierRow['isActive'] ?? 0) === 1)
+        {
+            $resolvedTierID   = (string) $tierRow['tierID'];
+            $resolvedTierName = (string) $tierRow['tierName'];
+        }
+        else
+        {
+            $fallbackRow = _g2ml_fetchFallbackTierRow();
+
+            if ($fallbackRow === false || $fallbackRow === null)
+            {
+                error_log('[Go2My.Link] ERROR: pricing — fallback tier lookup failed/empty resolving org "' . $orgHandle . '" — falling back to legacy resolution.');
+
+                return false;
+            }
+
+            $resolvedTierID   = (string) $fallbackRow['tierID'];
+            $resolvedTierName = (string) $fallbackRow['tierName'];
+        }
+
+        // ---------------------------------------------------------------
+        // 2. Load ACTIVE features.
+        // ---------------------------------------------------------------
+        $features = _g2ml_pricingFetchFeatures();
+
+        if ($features === false)
+        {
+            error_log('[Go2My.Link] ERROR: pricing — feature registry lookup failed resolving org "' . $orgHandle . '" — falling back to legacy resolution.');
+
+            return false;
+        }
+
+        // ---------------------------------------------------------------
+        // 3. Load the tier's currently-effective tblTierFeatures rows,
+        //    reduced to one (latest-effectiveFrom) row per feature.
+        // ---------------------------------------------------------------
+        $tierFeatureRows = _g2ml_pricingFetchTierFeatures($resolvedTierID);
+
+        if ($tierFeatureRows === false)
+        {
+            error_log('[Go2My.Link] ERROR: pricing — tier-feature lookup failed for tier "' . $resolvedTierID . '" — falling back to legacy resolution.');
+
+            return false;
+        }
+
+        $tierFeatureByFeatureUID = _g2ml_pricingReduceLatestEffective($tierFeatureRows);
+
+        // ---------------------------------------------------------------
+        // 4. Load the org's ACTIVE, currently-effective overrides.
+        // ---------------------------------------------------------------
+        $orgOverrideRows = _g2ml_pricingFetchOrgOverrides($orgHandle);
+
+        if ($orgOverrideRows === false)
+        {
+            error_log('[Go2My.Link] ERROR: pricing — org-override lookup failed for org "' . $orgHandle . '" — falling back to legacy resolution.');
+
+            return false;
+        }
+
+        $orgOverridesByFeatureUID = [];
+
+        foreach ($orgOverrideRows as $overrideRow)
+        {
+            $featureUIDKey = (string) $overrideRow['featureUID'];
+
+            if (!isset($orgOverridesByFeatureUID[$featureUIDKey]))
+            {
+                $orgOverridesByFeatureUID[$featureUIDKey] = [];
+            }
+
+            $orgOverridesByFeatureUID[$featureUIDKey][] = $overrideRow;
+        }
+
+        // ---------------------------------------------------------------
+        // 5. Merge per feature.
+        // ---------------------------------------------------------------
+        $resolvedFeatures = [];
+
+        foreach ($features as $featureRow)
+        {
+            $featureUIDKey = (string) $featureRow['featureUID'];
+            $slug          = (string) $featureRow['featureSlug'];
+
+            $tierFeatureRow  = $tierFeatureByFeatureUID[$featureUIDKey] ?? null;
+            $featureOverrides = $orgOverridesByFeatureUID[$featureUIDKey] ?? [];
+
+            $resolvedFeatures[$slug] = _g2ml_pricingResolveFeatureValue($featureRow, $tierFeatureRow, $featureOverrides);
+        }
+
+        // ---------------------------------------------------------------
+        // 6. Umbrella rule: hasAdvancedRedirects reports ON when the
+        //    umbrella row itself is ON OR any granular redirects.* flag
+        //    resolved true.
+        // ---------------------------------------------------------------
+        if (isset($resolvedFeatures['redirects.advanced']))
+        {
+            $anyGranularRedirectOn = false;
+
+            foreach ($resolvedFeatures as $slug => $resolvedValue)
+            {
+                if ($slug === 'redirects.advanced')
+                {
+                    continue;
+                }
+
+                if (str_starts_with($slug, 'redirects.') && $resolvedValue['value'] === true)
+                {
+                    $anyGranularRedirectOn = true;
+                }
+            }
+
+            if ($anyGranularRedirectOn === true)
+            {
+                $resolvedFeatures['redirects.advanced']['value'] = true;
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // 7. Emit the legacy-shaped array via legacyColumn mapping.
+        // ---------------------------------------------------------------
+        $legacyShaped = [
+            'tierID'               => $resolvedTierID,
+            'tierName'             => $resolvedTierName,
+            'maxLinks'             => null,
+            'maxCustomDomains'     => null,
+            'maxAPIRequestsPerDay' => null,
+            'maxLinksPages'        => null,
+            'hasAdvancedRedirects' => false,
+            'hasAnalytics'         => false,
+            'hasQRCodes'           => false,
+            'hasAPIAccess'         => false,
+            'hasPrioritySupport'   => false,
+            'hasCustomHTML'        => false,
+        ];
+
+        foreach ($features as $featureRow)
+        {
+            $legacyColumn = $featureRow['legacyColumn'] ?? null;
+
+            if ($legacyColumn === null || $legacyColumn === '')
+            {
+                continue;
+            }
+
+            $slug     = (string) $featureRow['featureSlug'];
+            $resolved = $resolvedFeatures[$slug] ?? null;
+
+            if ($resolved === null)
+            {
+                continue;
+            }
+
+            if ($resolved['isUnlimited'] === true)
+            {
+                $legacyShaped[$legacyColumn] = null;
+            }
+            elseif ($resolved['valueType'] === 'boolean')
+            {
+                $legacyShaped[$legacyColumn] = ($resolved['value'] === true);
+            }
+            elseif ($resolved['value'] === null)
+            {
+                $legacyShaped[$legacyColumn] = null;
+            }
+            else
+            {
+                $legacyShaped[$legacyColumn] = (int) $resolved['value'];
+            }
+        }
+
+        $legacyShaped['unlimited'] = false;
+        $legacyShaped['source']    = 'pricing_engine';
+
+        // ---------------------------------------------------------------
+        // 8. Additionally expose every granular slug for new callers.
+        // ---------------------------------------------------------------
+        $featuresOut = [];
+
+        foreach ($resolvedFeatures as $slug => $resolvedValue)
+        {
+            $featuresOut[$slug] = $resolvedValue['value'];
+        }
+
+        $legacyShaped['features'] = $featuresOut;
+
+        return $legacyShaped;
+    }
+    catch (Throwable $unexpectedError)
+    {
+        error_log('[Go2My.Link] ERROR: pricing — unexpected exception resolving org "' . $orgHandle . '": ' . $unexpectedError->getMessage() . ' — falling back to legacy resolution.');
+
+        return false;
+    }
+}
+
+/**
+ * Granular boolean feature check for NEW call sites (uses the full dot-
+ * namespaced featureSlug registry, not the legacy has* whitelist).
+ *
+ * Returns false whenever the engine is OFF — existing callers must keep
+ * using g2ml_canUseFeature() until an operator switches the engine on; this
+ * function is for code written AFTER that migration.
+ *
+ * @param  string $orgHandle
+ * @param  string $featureSlug
+ * @return bool
+ */
+function g2ml_pricingCanUse(string $orgHandle, string $featureSlug): bool
+{
+    if (g2ml_pricingEngineEnabled() !== true)
+    {
+        return false;
+    }
+
+    $tier = g2ml_pricingResolveOrgTier($orgHandle);
+
+    if (!is_array($tier) || !isset($tier['features']) || !is_array($tier['features']))
+    {
+        error_log('[Go2My.Link] WARNING: pricing — g2ml_pricingCanUse() could not resolve org "' . $orgHandle . '" — denying.');
+
+        return false;
+    }
+
+    if (!array_key_exists($featureSlug, $tier['features']))
+    {
+        error_log('[Go2My.Link] WARNING: pricing — g2ml_pricingCanUse() called with an unrecognised/inactive feature slug "' . $featureSlug . '" — denying.');
+
+        return false;
+    }
+
+    if ($tier['features'][$featureSlug] === true)
+    {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Granular limit/quota check for NEW call sites, same contract shape as
+ * g2ml_checkLimit(): fail-OPEN (allowed, unlimited) on an unrecognised slug
+ * or a system error, since a caller-supplied typo or an engine outage is an
+ * entitlement-SYSTEM defect, not a genuine over-limit condition.
+ *
+ * @param  string $orgHandle
+ * @param  string $featureSlug
+ * @param  int    $currentCount  The caller's current usage count (negative
+ *                                values are treated as 0).
+ * @return array  ['allowed' => bool, 'limit' => int|null, 'remaining' => int|null]
+ */
+function g2ml_pricingGetLimit(string $orgHandle, string $featureSlug, int $currentCount): array
+{
+    $failOpen = [
+        'allowed'   => true,
+        'limit'     => null,
+        'remaining' => null,
+    ];
+
+    if (g2ml_pricingEngineEnabled() !== true)
+    {
+        return $failOpen;
+    }
+
+    $tier = g2ml_pricingResolveOrgTier($orgHandle);
+
+    if (!is_array($tier) || !isset($tier['features']) || !is_array($tier['features']))
+    {
+        error_log('[Go2My.Link] WARNING: pricing — g2ml_pricingGetLimit() could not resolve org "' . $orgHandle . '" — failing OPEN (allowed, unlimited).');
+
+        return $failOpen;
+    }
+
+    if (!array_key_exists($featureSlug, $tier['features']))
+    {
+        error_log('[Go2My.Link] WARNING: pricing — g2ml_pricingGetLimit() called with an unrecognised/inactive feature slug "' . $featureSlug . '" — failing OPEN (allowed, unlimited).');
+
+        return $failOpen;
+    }
+
+    $limitValue = $tier['features'][$featureSlug];
+
+    if ($limitValue === null)
+    {
+        return $failOpen;
+    }
+
+    $limitValueInt = (int) $limitValue;
+
+    if ($currentCount < 0)
+    {
+        $currentCountSafe = 0;
+    }
+    else
+    {
+        $currentCountSafe = $currentCount;
+    }
+
+    if ($currentCountSafe < $limitValueInt)
+    {
+        $allowed = true;
+    }
+    else
+    {
+        $allowed = false;
+    }
+
+    $remaining = $limitValueInt - $currentCountSafe;
+
+    if ($remaining < 0)
+    {
+        $remaining = 0;
+    }
+
+    return [
+        'allowed'   => $allowed,
+        'limit'     => $limitValueInt,
+        'remaining' => $remaining,
+    ];
+}
+
+/**
+ * Probabilistic prune of old tblUsageEvents rows (1-in-100 request sweep),
+ * mirroring tblAPIRequestLog's retention pattern (api_ratelimit.php) — no
+ * cron dependency on Dreamhost shared hosting.
+ *
+ * @return void
+ */
+function _g2ml_pricingPruneUsageEvents(): void
+{
+    $retentionDays = (int) _g2ml_pricingReadSetting('billing.usage_event_retention_days', 90);
+
+    if ($retentionDays <= 0)
+    {
+        return;
+    }
+
+    dbDelete(
+        'DELETE FROM tblUsageEvents WHERE createdAt < DATE_SUB(NOW(), INTERVAL ? DAY)',
+        'i',
+        [$retentionDays]
+    );
+}
+
+/**
+ * Record metered usage for a meterable feature. A NO-OP (returns true
+ * without touching the database) unless 'billing.usage_metering_enabled' is
+ * '1' — so this is safe to sprinkle into call sites ahead of the engine (or
+ * even ahead of PAYG) going live.
+ *
+ * Metering failures are LOGGED and return false but NEVER throw — the
+ * caller must never let a metering failure block the underlying action
+ * (creating a link, serving a redirect, etc.).
+ *
+ * @param  string      $orgHandle
+ * @param  string      $featureSlug   Must be an ACTIVE, isMeterable=1 feature.
+ * @param  int         $quantity      Units consumed by this event (default 1).
+ * @param  string|null $eventRef      Optional idempotency reference for the
+ *                                     optional fine-grained event ledger.
+ * @return bool
+ */
+function g2ml_pricingMeterUsage(string $orgHandle, string $featureSlug, int $quantity = 1, ?string $eventRef = null): bool
+{
+    try
+    {
+        $meteringEnabled = (_g2ml_pricingReadSetting('billing.usage_metering_enabled', '0') === '1');
+
+        if ($meteringEnabled !== true)
+        {
+            return true;
+        }
+
+        $features = _g2ml_pricingFetchFeatures();
+
+        if ($features === false)
+        {
+            error_log('[Go2My.Link] ERROR: pricing — feature registry lookup failed metering "' . $featureSlug . '" for org "' . $orgHandle . '" — usage not recorded.');
+
+            return false;
+        }
+
+        $featureUID  = null;
+        $isMeterable = false;
+        $quotaPeriod = null;
+
+        foreach ($features as $featureRow)
+        {
+            if ((string) $featureRow['featureSlug'] === $featureSlug)
+            {
+                $featureUID  = (int) $featureRow['featureUID'];
+                $isMeterable = ((int) ($featureRow['isMeterable'] ?? 0) === 1);
+                $quotaPeriod = $featureRow['quotaPeriod'] ?? null;
+                break;
+            }
+        }
+
+        if ($featureUID === null || $isMeterable !== true)
+        {
+            error_log('[Go2My.Link] WARNING: pricing — g2ml_pricingMeterUsage() called for an unknown/non-meterable feature slug "' . $featureSlug . '" — usage not recorded.');
+
+            return false;
+        }
+
+        if ($quotaPeriod === 'day')
+        {
+            $periodType  = 'day';
+            $periodStart = date('Y-m-d');
+        }
+        elseif ($quotaPeriod === 'billing_period')
+        {
+            // Aligning to a subscription's own anniversary is left for the
+            // billing-integration phase; a calendar-month bucket is a safe,
+            // conservative stand-in until then.
+            $periodType  = 'billing_period';
+            $periodStart = date('Y-m-01');
+        }
+        else
+        {
+            $periodType  = 'month';
+            $periodStart = date('Y-m-01');
+        }
+
+        $counterUpserted = dbInsert(
+            'INSERT INTO tblUsageCounters (orgHandle, featureUID, periodType, periodStart, usedCount, lastEventAt) '
+            . 'VALUES (?, ?, ?, ?, ?, NOW()) '
+            . 'ON DUPLICATE KEY UPDATE usedCount = usedCount + VALUES(usedCount), lastEventAt = VALUES(lastEventAt)',
+            'sissi',
+            [$orgHandle, $featureUID, $periodType, $periodStart, $quantity]
+        );
+
+        if ($counterUpserted === false)
+        {
+            error_log('[Go2My.Link] ERROR: pricing — usage counter UPSERT failed for org "' . $orgHandle . '", feature "' . $featureSlug . '" — usage not recorded (the underlying action was NOT blocked by this).');
+
+            return false;
+        }
+
+        $eventLogEnabled = (_g2ml_pricingReadSetting('billing.usage_event_log_enabled', '0') === '1');
+
+        if ($eventLogEnabled === true)
+        {
+            $eventInserted = dbInsert(
+                'INSERT INTO tblUsageEvents (orgHandle, featureUID, quantity, eventRef) VALUES (?, ?, ?, ?)',
+                'siis',
+                [$orgHandle, $featureUID, $quantity, $eventRef]
+            );
+
+            if ($eventInserted === false)
+            {
+                error_log('[Go2My.Link] WARNING: pricing — usage EVENT log insert failed for org "' . $orgHandle . '", feature "' . $featureSlug . '" — the counter update above still succeeded.');
+            }
+
+            if (mt_rand(1, 100) === 1)
+            {
+                _g2ml_pricingPruneUsageEvents();
+            }
+        }
+
+        return true;
+    }
+    catch (Throwable $unexpectedError)
+    {
+        error_log('[Go2My.Link] ERROR: pricing — unexpected exception metering "' . $featureSlug . '" for org "' . $orgHandle . '": ' . $unexpectedError->getMessage() . ' — usage not recorded (never blocks the action).');
+
+        return false;
+    }
+}
+
+/**
+ * Clear this file's request-scoped caches (currently just the engine-enabled
+ * flag). Mirrors entitlements.php's g2ml_clearOrgTierCache() shape (an
+ * optional orgHandle, ignored here since the engine-enabled flag is global —
+ * kept for signature symmetry and future per-org caching). Also invalidates
+ * entitlements.php's own tier cache (function_exists-guarded) so a caller
+ * that changes pricing-engine data mid-request cannot see a stale legacy-path
+ * tier either.
+ *
+ * @param  string|null $orgHandle  Present for signature symmetry with
+ *                                  g2ml_clearOrgTierCache(); unused because
+ *                                  the only cache here (the engine flag) is
+ *                                  global, not per-org.
+ * @return void
+ */
+function g2ml_clearPricingCache(?string $orgHandle = null): void
+{
+    unset($GLOBALS['g2ml_pricing_engine_enabled_cache']);
+
+    if (function_exists('g2ml_clearOrgTierCache'))
+    {
+        g2ml_clearOrgTierCache($orgHandle);
+    }
+}

--- a/web/_includes/page_init.php
+++ b/web/_includes/page_init.php
@@ -235,6 +235,17 @@ require_once G2ML_FUNCTIONS . DIRECTORY_SEPARATOR . 'session.php';
 require_once G2ML_FUNCTIONS . DIRECTORY_SEPARATOR . 'auth.php';
 require_once G2ML_FUNCTIONS . DIRECTORY_SEPARATOR . 'org.php';
 require_once G2ML_FUNCTIONS . DIRECTORY_SEPARATOR . 'account_types.php';
+
+// Optional pricing-engine resolver (#TBD — scaffold). Only DEFINES functions;
+// the guarded hook inside entitlements.php's _g2ml_resolveOrgTier() is the
+// only place that calls into it, and only when
+// getSetting('billing.pricing_engine_enabled') === '1'. Loaded immediately
+// before entitlements.php so that hook can see g2ml_pricingResolveOrgTier().
+if (file_exists(G2ML_FUNCTIONS . DIRECTORY_SEPARATOR . 'pricing.php'))
+{
+    require_once G2ML_FUNCTIONS . DIRECTORY_SEPARATOR . 'pricing.php';
+}
+
 require_once G2ML_FUNCTIONS . DIRECTORY_SEPARATOR . 'entitlements.php';
 
 // Layer 4 — Compliance, Privacy & Security Response (depend on Layers 1+2+3)

--- a/web/_sql/migrations/020_pricing_engine.sql
+++ b/web/_sql/migrations/020_pricing_engine.sql
@@ -1,0 +1,857 @@
+-- Copyright (c) 2024–2026 MWBM Partners Ltd (MWservices).
+-- All rights reserved.
+--
+-- This source code is proprietary and confidential.
+-- Unauthorised copying, modification, or distribution is strictly prohibited.
+
+-- =============================================================================
+-- Go2My.Link — Migration 020: Flexible Pricing & Entitlement Engine (scaffold)
+-- =============================================================================
+-- Brings an ALREADY-IMPORTED database up to date with the additive pricing
+-- engine scaffold: the 10 new tables + verification view from
+-- web/_sql/schema/036_pricing_engine.sql, the feature-registry seed + legacy
+-- backfill from web/_sql/seeds/018_pricing_feature_registry.sql, and the nine
+-- billing.* engine-switch settings (ALL seeded OFF/'0') from
+-- web/_sql/seeds/019_pricing_settings.sql — reproduced here VERBATIM as
+-- CREATE TABLE IF NOT EXISTS + idempotent INSERTs, so running this file is
+-- byte-for-byte equivalent to those three files having been present at
+-- install time.
+--
+-- ⚠️  FRESH INSTALLS DO NOT NEED THIS FILE: schema 036 + seeds 018/019 are
+--     already part of the base install (the web installer globs
+--     web/_sql/schema/ and web/_sql/seeds/ in filename-sort order, so a fresh
+--     database already has every table and seed row below). Run this
+--     migration ONLY to bring an ALREADY-IMPORTED earlier schema (one deployed
+--     before this pricing-engine phase existed) up to date.
+--
+-- NO ALTERs, NO information_schema GUARD PROCEDURES NEEDED. Every statement
+-- below is either `CREATE TABLE IF NOT EXISTS`, `CREATE OR REPLACE VIEW`, or
+-- an idempotent `INSERT … ON DUPLICATE KEY UPDATE` / `INSERT … SELECT …
+-- ON DUPLICATE KEY UPDATE`. Unlike migration 019 (which needed a collapse-
+-- then-constrain ALTER sequence), this migration only ADDS brand-new objects,
+-- so there is nothing to guard against a partial prior run — re-running this
+-- entire file is always safe.
+--
+-- NO ZERO-DATE GUARDS NEEDED. No column here is populated from a legacy DATE/
+-- DATETIME column that might hold MySQL's zero-date sentinel ('0000-00-00') —
+-- every DATETIME column added below is either DEFAULT NULL or
+-- DEFAULT CURRENT_TIMESTAMP, so the zero-date guard pattern used by other
+-- migrations in this directory does not apply here.
+--
+-- ORDER MATTERS — TABLES, THEN THE VIEW, THEN SEED DATA. Tables are created in
+-- FK dependency order (features → price plans → tier features → org overrides
+-- → coupons → coupon redemptions → subscription plans → usage counters →
+-- usage credits → usage events), matching web/_sql/schema/036_pricing_engine.sql
+-- exactly. The verification view is created after all ten tables exist. The
+-- feature-registry seed runs before the legacy backfill (the backfill's
+-- INSERT…SELECT joins against the just-seeded tblFeatures.legacyColumn), and
+-- both run before the settings block (unrelated tables, but kept in the same
+-- relative order as the fresh-install file-sort sequence for clarity).
+--
+-- ZERO BEHAVIOUR CHANGE. Every billing.* setting below seeds to '0' (except
+-- the two currency/region display defaults). Until an operator flips
+-- billing.pricing_engine_enabled to '1', web/_functions/entitlements.php
+-- resolves tiers exactly as it did before this migration ran.
+--
+-- @package    Go2My.Link
+-- @subpackage Migrations
+-- @version    1.0.0
+-- @since      v1.6.0 — Pricing Engine phase (scaffold)
+--
+-- 📖 References:
+--     - Schema (fresh-install source of truth): web/_sql/schema/036_pricing_engine.sql
+--     - Feature/backfill seed:                  web/_sql/seeds/018_pricing_feature_registry.sql
+--     - Engine-switch seed:                     web/_sql/seeds/019_pricing_settings.sql
+--     - Resolver:                               web/_functions/pricing.php
+--     - Migration-header wording precedent:      web/_sql/migrations/016_linkspage_custom_html.sql
+-- =============================================================================
+
+USE `mwtools_Go2MyLink`;
+
+-- =============================================================================
+-- PART 1 — TABLES (verbatim from web/_sql/schema/036_pricing_engine.sql).
+-- See that file for the full per-table design rationale; only short pointer
+-- comments are kept here to avoid duplicating hundreds of lines of prose.
+-- =============================================================================
+
+-- 1. tblFeatures — the feature registry (see schema 036 §1)
+CREATE TABLE IF NOT EXISTS `tblFeatures` (
+    `featureUID`            BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT
+        COMMENT 'Unique row identifier',
+    `featureSlug`           VARCHAR(100)        NOT NULL
+        COMMENT 'Stable dot-namespaced identifier (e.g. links.max, redirects.geo, api.requests_per_day). NEVER renamed once live — display text changes go in featureName.',
+    `featureName`           VARCHAR(150)        NOT NULL
+        COMMENT 'Human-readable name for admin UI / pricing page rows',
+    `featureDescription`    TEXT                DEFAULT NULL
+        COMMENT 'What this feature gates, for admin UI and pricing-page tooltips',
+    `valueType`             ENUM('boolean', 'limit', 'quota', 'enum', 'config')
+                            NOT NULL DEFAULT 'boolean'
+        COMMENT 'How entitlement values for this feature are typed and enforced',
+    `valueUnit`             VARCHAR(50)         DEFAULT NULL
+        COMMENT 'Display/metering unit for limit/quota types (e.g. links, domains, requests, days)',
+    `quotaPeriod`           ENUM('day', 'month', 'billing_period')
+                            DEFAULT NULL
+        COMMENT 'For valueType=quota only: the window the allowance renews over (NULL otherwise)',
+    `allowedValues`         TEXT                DEFAULT NULL
+        COMMENT 'For valueType=enum only: newline-separated permitted values; NULL = not applicable',
+    `defaultValueBoolean`   TINYINT(1) UNSIGNED DEFAULT NULL
+        COMMENT 'Safe-floor default for boolean features when a tier has no row (normally 0 = off)',
+    `defaultValueInt`       BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'Safe-floor default for limit/quota features when a tier has no row (normally 0)',
+    `defaultValueString`    VARCHAR(255)        DEFAULT NULL
+        COMMENT 'Safe-floor default for enum features when a tier has no row',
+    `defaultValueJSON`      JSON                DEFAULT NULL
+        COMMENT 'Safe-floor default for config features when a tier has no row',
+    `defaultIsUnlimited`    TINYINT(1) UNSIGNED NOT NULL DEFAULT 0
+        COMMENT 'Whether the safe-floor default is "unlimited" (1) — kept EXPLICIT rather than overloading NULL',
+    `category`              VARCHAR(50)         NOT NULL DEFAULT 'general'
+        COMMENT 'Grouping for admin UI / pricing matrix (links, domains, redirects, analytics, api, qr, linkspage, org, support)',
+    `isMeterable`           TINYINT(1) UNSIGNED NOT NULL DEFAULT 0
+        COMMENT 'Whether this feature may serve as a PAYG metering dimension',
+    `legacyColumn`          VARCHAR(50)         DEFAULT NULL
+        COMMENT 'The hard-coded tblSubscriptionTiers column this row replaces; drives the backfill and legacy-shape output; NULL for new granular features',
+    `sortOrder`             INT UNSIGNED        NOT NULL DEFAULT 0
+        COMMENT 'Display order within category on pricing matrix / admin UI',
+    `isActive`              TINYINT(1) UNSIGNED NOT NULL DEFAULT 1
+        COMMENT 'Whether this feature participates in resolution (0 = parked; resolver ignores it entirely)',
+    `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`             DATETIME            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`featureUID`),
+    UNIQUE KEY `UQ_feature_slug` (`featureSlug`),
+    UNIQUE KEY `UQ_feature_legacy_column` (`legacyColumn`),
+    INDEX `IDX_feature_category` (`category`, `sortOrder`),
+    INDEX `IDX_feature_active` (`isActive`),
+    INDEX `IDX_feature_meterable` (`isMeterable`, `isActive`)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Feature registry — every gateable capability is one row; adding a feature never needs a schema change';
+
+-- 2. tblPricePlans — the flexible price book (see schema 036 §2)
+CREATE TABLE IF NOT EXISTS `tblPricePlans` (
+    `planUID`               BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT
+        COMMENT 'Unique row identifier',
+    `planSlug`              VARCHAR(100)        NOT NULL
+        COMMENT 'Stable identifier (e.g. pro-monthly-gbp, pro-lifetime-founder, payg-capped-pro-gbp)',
+    `planName`              VARCHAR(150)        NOT NULL
+        COMMENT 'Display name (e.g. "Pro — Monthly", "Founding Member Lifetime")',
+    `planDescription`       TEXT                DEFAULT NULL
+        COMMENT 'Marketing/admin description of this price plan',
+    `tierID`                VARCHAR(50)         DEFAULT NULL
+        COMMENT 'FK to tblSubscriptionTiers.tierID — the tier this plan sells. NULL for tier-less plans (addon, credit_pack, one_off)',
+    `planType`              ENUM('recurring', 'lifetime', 'one_off', 'payg', 'payg_capped', 'addon', 'credit_pack')
+                            NOT NULL DEFAULT 'recurring'
+        COMMENT 'Price structure (see schema 036 §2 for full semantics)',
+    `billingInterval`       ENUM('month', 'year')
+                            DEFAULT NULL
+        COMMENT 'Recurring interval unit; NULL for lifetime/one_off/credit_pack. PAYG plans bill monthly in arrears',
+    `intervalCount`         TINYINT UNSIGNED    NOT NULL DEFAULT 1
+        COMMENT 'Multiplier on billingInterval (quarterly = month × 3); ignored when billingInterval is NULL',
+    `amount`                DECIMAL(10, 2)      NOT NULL DEFAULT 0.00
+        COMMENT 'Flat price per interval (or once, for lifetime/one_off/credit_pack) in `currency`. 0.00 for pure PAYG',
+    `currency`              CHAR(3)             NOT NULL DEFAULT 'GBP'
+        COMMENT 'ISO 4217 currency code — one plan row per currency variant',
+    `region`                VARCHAR(10)         DEFAULT NULL
+        COMMENT 'Region code this plan is offered in (GB, EU, US, ROW…); NULL = all regions',
+    `perSeatAmount`         DECIMAL(10, 2)      DEFAULT NULL
+        COMMENT 'Per-seat price per interval. NULL = per-org flat pricing (amount only)',
+    `minSeats`              SMALLINT UNSIGNED   DEFAULT NULL
+        COMMENT 'Minimum billable seats when perSeatAmount is set (NULL = 1)',
+    `maxSeats`              SMALLINT UNSIGNED   DEFAULT NULL
+        COMMENT 'Maximum purchasable seats on this plan (NULL = no cap)',
+    `trialDays`             SMALLINT UNSIGNED   NOT NULL DEFAULT 0
+        COMMENT 'Free-trial length in days (feeds tblSubscriptions.trialEndsAt); 0 = no trial',
+    `meteredFeatureUID`     BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'FK to tblFeatures.featureUID — the metering dimension for payg/payg_capped/credit_pack',
+    `unitPrice`             DECIMAL(12, 6)      DEFAULT NULL
+        COMMENT 'PAYG price per unitSize units of the metered feature',
+    `unitSize`              INT UNSIGNED        DEFAULT NULL
+        COMMENT 'Units per unitPrice (e.g. 1000 → price per 1,000 tracked clicks). NULL when not metered',
+    `includedUnits`         BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'Free allowance per period before PAYG metering starts (NULL = none)',
+    `capAmount`             DECIMAL(10, 2)      DEFAULT NULL
+        COMMENT 'payg_capped: maximum metered spend per period. NULL + equivalentPlanUID set = cap equals that plan''s CURRENT amount',
+    `equivalentPlanUID`     BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'Self-FK to the flat tblPricePlans row this PAYG cap is pegged to',
+    `capBehaviour`          ENUM('flat_convert', 'hard_stop', 'notify_only')
+                            DEFAULT NULL
+        COMMENT 'What happens when the cap is reached (payg_capped only)',
+    `creditUnits`           BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'credit_pack only: metered units granted per purchase (lands in tblUsageCredits)',
+    `validFrom`             DATETIME            DEFAULT NULL
+        COMMENT 'Offer window start (limited-time / intro pricing); NULL = always offerable while isActive',
+    `validUntil`            DATETIME            DEFAULT NULL
+        COMMENT 'Offer window end — existing subscriptions are grandfathered via tblSubscriptionPlans',
+    `maxSubscriptions`      INT UNSIGNED        DEFAULT NULL
+        COMMENT 'Scarcity cap on total take-up (e.g. 500 founding lifetime deals); NULL = uncapped',
+    `currentSubscriptions`  INT UNSIGNED        NOT NULL DEFAULT 0
+        COMMENT 'Running take-up count, maintained by the purchase flow',
+    `isDefault`             TINYINT(1) UNSIGNED NOT NULL DEFAULT 0
+        COMMENT 'The advertised plan for its (tierID, currency, region, billingInterval) group on the pricing page',
+    `isVisible`             TINYINT(1) UNSIGNED NOT NULL DEFAULT 1
+        COMMENT 'Publicly listed (1) vs hidden/deal-only/grandfather-only (0)',
+    `isActive`              TINYINT(1) UNSIGNED NOT NULL DEFAULT 0
+        COMMENT 'DISABLED BY DEFAULT (0): a plan must be explicitly activated by an operator before it can be offered',
+    `sortOrder`             INT UNSIGNED        NOT NULL DEFAULT 0
+        COMMENT 'Display order on the pricing page',
+    `metadataJSON`          JSON                DEFAULT NULL
+        COMMENT 'Provider mapping and future extension data (e.g. {"provider":"stripe","priceId":"price_..."})',
+    `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`             DATETIME            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`planUID`),
+    UNIQUE KEY `UQ_priceplan_slug` (`planSlug`),
+    INDEX `IDX_priceplan_tier` (`tierID`, `isActive`, `isDefault`),
+    INDEX `IDX_priceplan_type` (`planType`, `isActive`),
+    INDEX `IDX_priceplan_currency_region` (`currency`, `region`, `isActive`),
+    INDEX `IDX_priceplan_window` (`validFrom`, `validUntil`),
+    CONSTRAINT `FK_priceplan_tier`
+        FOREIGN KEY (`tierID`)
+        REFERENCES `tblSubscriptionTiers` (`tierID`)
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT,
+    CONSTRAINT `FK_priceplan_metered_feature`
+        FOREIGN KEY (`meteredFeatureUID`)
+        REFERENCES `tblFeatures` (`featureUID`)
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT,
+    CONSTRAINT `FK_priceplan_equivalent_plan`
+        FOREIGN KEY (`equivalentPlanUID`)
+        REFERENCES `tblPricePlans` (`planUID`)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Price book — any number of simultaneous price plans per tier: recurring, lifetime, one-off, PAYG, PAYG-capped, add-ons, credit packs, per currency/region/offer-window';
+
+-- 3. tblTierFeatures — tier↔feature entitlement matrix (see schema 036 §3)
+CREATE TABLE IF NOT EXISTS `tblTierFeatures` (
+    `tierFeatureUID`        BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT
+        COMMENT 'Unique row identifier',
+    `tierID`                VARCHAR(50)         NOT NULL
+        COMMENT 'FK to tblSubscriptionTiers.tierID',
+    `featureUID`            BIGINT UNSIGNED     NOT NULL
+        COMMENT 'FK to tblFeatures.featureUID',
+    `valueBoolean`          TINYINT(1) UNSIGNED DEFAULT NULL
+        COMMENT 'Typed value for boolean features (NULL = not this type)',
+    `valueInt`              BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'Typed value for limit/quota features (NULL = not this type OR unlimited — see isUnlimited)',
+    `valueString`           VARCHAR(255)        DEFAULT NULL
+        COMMENT 'Typed value for enum features',
+    `valueJSON`             JSON                DEFAULT NULL
+        COMMENT 'Value for config features / complex values beyond the typed columns',
+    `isUnlimited`           TINYINT(1) UNSIGNED NOT NULL DEFAULT 0
+        COMMENT 'Explicit unlimited marker for limit/quota features (1 = ∞; resolver outputs legacy NULL)',
+    `effectiveFrom`         DATETIME            DEFAULT NULL
+        COMMENT 'When this entitlement value starts applying (NULL = since forever)',
+    `effectiveUntil`        DATETIME            DEFAULT NULL
+        COMMENT 'When this entitlement value stops applying (NULL = open-ended)',
+    `effectiveFromKey`      DATETIME
+                            GENERATED ALWAYS AS (COALESCE(`effectiveFrom`, '1000-01-01 00:00:00')) STORED
+        COMMENT 'NULL-collapsed mirror of effectiveFrom so undated rows dedupe in UQ_tierfeature (settings #150 idiom)',
+    `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`             DATETIME            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`tierFeatureUID`),
+    UNIQUE KEY `UQ_tierfeature` (`tierID`, `featureUID`, `effectiveFromKey`),
+    INDEX `IDX_tierfeature_feature` (`featureUID`),
+    INDEX `IDX_tierfeature_window` (`effectiveFrom`, `effectiveUntil`),
+    CONSTRAINT `FK_tierfeature_tier`
+        FOREIGN KEY (`tierID`)
+        REFERENCES `tblSubscriptionTiers` (`tierID`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+    CONSTRAINT `FK_tierfeature_feature`
+        FOREIGN KEY (`featureUID`)
+        REFERENCES `tblFeatures` (`featureUID`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Tier↔feature entitlement matrix as data — any feature grantable to any tier at any granularity, with effective-dating';
+
+-- 4. tblOrgFeatureOverrides — per-org overrides/add-ons/custom deals (see schema 036 §4)
+CREATE TABLE IF NOT EXISTS `tblOrgFeatureOverrides` (
+    `overrideUID`           BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT
+        COMMENT 'Unique row identifier',
+    `orgHandle`             VARCHAR(50)         NOT NULL
+        COMMENT 'FK to tblOrganisations.orgHandle — the single org this override applies to',
+    `featureUID`            BIGINT UNSIGNED     NOT NULL
+        COMMENT 'FK to tblFeatures.featureUID — the single feature being overridden',
+    `overrideMode`          ENUM('grant', 'deny', 'set', 'adjust')
+                            NOT NULL DEFAULT 'set'
+        COMMENT 'How this override combines with the tier value',
+    `valueBoolean`          TINYINT(1) UNSIGNED DEFAULT NULL
+        COMMENT 'set-mode replacement value for boolean features',
+    `valueInt`              BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'set-mode replacement value for limit/quota features',
+    `valueString`           VARCHAR(255)        DEFAULT NULL
+        COMMENT 'set-mode replacement value for enum features',
+    `valueJSON`             JSON                DEFAULT NULL
+        COMMENT 'set-mode replacement value for config features / complex values',
+    `isUnlimited`           TINYINT(1) UNSIGNED NOT NULL DEFAULT 0
+        COMMENT 'set-mode: explicit unlimited (1 = ∞ for this org, this feature)',
+    `adjustDelta`           BIGINT              DEFAULT NULL
+        COMMENT 'adjust-mode: SIGNED delta applied to the tier''s numeric value; NULL for other modes',
+    `effectiveFrom`         DATETIME            DEFAULT NULL
+        COMMENT 'When the override starts (NULL = immediately)',
+    `effectiveUntil`        DATETIME            DEFAULT NULL
+        COMMENT 'When the override lapses (NULL = until removed)',
+    `sourceType`            ENUM('addon', 'comp', 'custom_deal', 'trial', 'support', 'migration')
+                            NOT NULL DEFAULT 'custom_deal'
+        COMMENT 'Why this override exists (audit/reporting)',
+    `sourcePlanUID`         BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'FK to tblPricePlans.planUID when sourceType=addon/credit purchase',
+    `notes`                 TEXT                DEFAULT NULL
+        COMMENT 'Free-text audit note (who agreed what, ticket ref, etc.)',
+    `createdByUserUID`      BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'FK to tblUsers.userUID — the admin who created this override (NULL = system)',
+    `isActive`              TINYINT(1) UNSIGNED NOT NULL DEFAULT 1
+        COMMENT 'Soft on/off without losing the audit row',
+    `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`             DATETIME            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`overrideUID`),
+    INDEX `IDX_orgoverride_org_feature` (`orgHandle`, `featureUID`, `isActive`),
+    INDEX `IDX_orgoverride_feature` (`featureUID`),
+    INDEX `IDX_orgoverride_window` (`effectiveFrom`, `effectiveUntil`),
+    CONSTRAINT `FK_orgoverride_org`
+        FOREIGN KEY (`orgHandle`)
+        REFERENCES `tblOrganisations` (`orgHandle`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+    CONSTRAINT `FK_orgoverride_feature`
+        FOREIGN KEY (`featureUID`)
+        REFERENCES `tblFeatures` (`featureUID`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+    CONSTRAINT `FK_orgoverride_source_plan`
+        FOREIGN KEY (`sourcePlanUID`)
+        REFERENCES `tblPricePlans` (`planUID`)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL,
+    CONSTRAINT `FK_orgoverride_created_by`
+        FOREIGN KEY (`createdByUserUID`)
+        REFERENCES `tblUsers` (`userUID`)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Per-org feature overrides — add-ons, comps, custom deals, feature trials — applied on top of tier entitlements, with effective-dating and audit trail';
+
+-- 5. tblCoupons — discount/coupon engine (see schema 036 §5)
+CREATE TABLE IF NOT EXISTS `tblCoupons` (
+    `couponUID`             BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT
+        COMMENT 'Unique row identifier',
+    `couponCode`            VARCHAR(50)         DEFAULT NULL
+        COMMENT 'Redeemable code (NULL = automatic discount applied by rule)',
+    `couponName`            VARCHAR(255)        NOT NULL
+        COMMENT 'Display name (e.g. "Launch offer — 25% off 3 months")',
+    `discountKind`          ENUM('percentage', 'fixed_amount', 'free_periods', 'override_price')
+                            NOT NULL DEFAULT 'percentage'
+        COMMENT 'Discount mechanics (see schema 036 §5)',
+    `discountValue`         DECIMAL(10, 2)      NOT NULL DEFAULT 0.00
+        COMMENT 'Percentage (0–100), fixed amount off, or override price; ignored for free_periods',
+    `durationType`          ENUM('once', 'first_n_periods', 'forever', 'until_date')
+                            NOT NULL DEFAULT 'once'
+        COMMENT 'How long the discount keeps applying to a subscription (forever = lifetime discount)',
+    `durationPeriods`       SMALLINT UNSIGNED   DEFAULT NULL
+        COMMENT 'first_n_periods: number of billing periods discounted (also the N for free_periods)',
+    `durationUntil`         DATETIME            DEFAULT NULL
+        COMMENT 'until_date: last date the discount applies to renewals',
+    `applicablePlanUID`     BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'Restrict to one price plan (NULL = no plan restriction)',
+    `applicableTierID`      VARCHAR(50)         DEFAULT NULL
+        COMMENT 'Restrict to any plan of one tier (NULL = no tier restriction)',
+    `applicablePlanType`    ENUM('recurring', 'lifetime', 'one_off', 'payg', 'payg_capped', 'addon', 'credit_pack')
+                            DEFAULT NULL
+        COMMENT 'Restrict to a plan type; NULL = any',
+    `minAmount`             DECIMAL(10, 2)      DEFAULT NULL
+        COMMENT 'Minimum pre-discount charge for the coupon to apply (NULL = none)',
+    `maxUses`               INT UNSIGNED        DEFAULT NULL
+        COMMENT 'Global redemption cap (NULL = unlimited)',
+    `currentUses`           INT UNSIGNED        NOT NULL DEFAULT 0
+        COMMENT 'Running redemption count',
+    `perOrgMaxUses`         SMALLINT UNSIGNED   DEFAULT NULL
+        COMMENT 'Per-organisation redemption cap (NULL = unlimited; typical value 1)',
+    `isStackable`           TINYINT(1) UNSIGNED NOT NULL DEFAULT 0
+        COMMENT 'Whether this coupon may combine with others',
+    `stackingGroup`         VARCHAR(50)         DEFAULT NULL
+        COMMENT 'Coupons sharing a group are mutually exclusive even when stackable',
+    `legacyDiscountUID`     BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'FK to tblPaymentDiscounts.discountUID when migrated from the legacy table',
+    `validFrom`             DATETIME            DEFAULT NULL
+        COMMENT 'Redemption window start (limited-time offers)',
+    `validUntil`            DATETIME            DEFAULT NULL
+        COMMENT 'Redemption window end',
+    `isActive`              TINYINT(1) UNSIGNED NOT NULL DEFAULT 0
+        COMMENT 'DISABLED BY DEFAULT (0) — a coupon must be explicitly activated',
+    `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`             DATETIME            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`couponUID`),
+    UNIQUE KEY `UQ_coupon_code` (`couponCode`),
+    INDEX `IDX_coupon_active_window` (`isActive`, `validFrom`, `validUntil`),
+    INDEX `IDX_coupon_plan` (`applicablePlanUID`),
+    INDEX `IDX_coupon_tier` (`applicableTierID`),
+    CONSTRAINT `FK_coupon_plan`
+        FOREIGN KEY (`applicablePlanUID`)
+        REFERENCES `tblPricePlans` (`planUID`)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL,
+    CONSTRAINT `FK_coupon_tier`
+        FOREIGN KEY (`applicableTierID`)
+        REFERENCES `tblSubscriptionTiers` (`tierID`)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL,
+    CONSTRAINT `FK_coupon_legacy_discount`
+        FOREIGN KEY (`legacyDiscountUID`)
+        REFERENCES `tblPaymentDiscounts` (`discountUID`)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Coupon/discount engine — intro, limited-time, lifetime, first-N-periods, price-override and free-period discounts with stacking rules and per-plan/tier/type applicability';
+
+-- 6. tblCouponRedemptions — enforces coupon usage caps (see schema 036 §6)
+CREATE TABLE IF NOT EXISTS `tblCouponRedemptions` (
+    `redemptionUID`         BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT
+        COMMENT 'Unique row identifier',
+    `couponUID`             BIGINT UNSIGNED     NOT NULL
+        COMMENT 'FK to tblCoupons.couponUID',
+    `orgHandle`             VARCHAR(50)         NOT NULL
+        COMMENT 'FK to tblOrganisations.orgHandle — the redeeming org',
+    `subscriptionUID`       BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'FK to tblSubscriptions.subscriptionUID the coupon is attached to (NULL for one-off purchases)',
+    `paymentUID`            BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'FK to tblPayments.paymentUID of the first discounted payment (NULL until first charge)',
+    `amountDiscounted`      DECIMAL(10, 2)      NOT NULL DEFAULT 0.00
+        COMMENT 'Total discounted so far under this redemption',
+    `periodsApplied`        SMALLINT UNSIGNED   NOT NULL DEFAULT 0
+        COMMENT 'How many billing periods have received this discount',
+    `redeemedAt`            DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP
+        COMMENT 'When the coupon was redeemed',
+    `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`             DATETIME            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`redemptionUID`),
+    INDEX `IDX_redemption_coupon_org` (`couponUID`, `orgHandle`),
+    INDEX `IDX_redemption_org` (`orgHandle`),
+    INDEX `IDX_redemption_subscription` (`subscriptionUID`),
+    CONSTRAINT `FK_redemption_coupon`
+        FOREIGN KEY (`couponUID`)
+        REFERENCES `tblCoupons` (`couponUID`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+    CONSTRAINT `FK_redemption_org`
+        FOREIGN KEY (`orgHandle`)
+        REFERENCES `tblOrganisations` (`orgHandle`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+    CONSTRAINT `FK_redemption_subscription`
+        FOREIGN KEY (`subscriptionUID`)
+        REFERENCES `tblSubscriptions` (`subscriptionUID`)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL,
+    CONSTRAINT `FK_redemption_payment`
+        FOREIGN KEY (`paymentUID`)
+        REFERENCES `tblPayments` (`paymentUID`)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Coupon redemption ledger — enforces global/per-org usage caps and first-N-periods duration, and audits discount attribution';
+
+-- 7. tblSubscriptionPlans — subscription ↔ price-plan pin / grandfathering (see schema 036 §7)
+CREATE TABLE IF NOT EXISTS `tblSubscriptionPlans` (
+    `subscriptionPlanUID`   BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT
+        COMMENT 'Unique row identifier',
+    `subscriptionUID`       BIGINT UNSIGNED     NOT NULL
+        COMMENT 'FK to tblSubscriptions.subscriptionUID — the legacy subscription row this plan context attaches to',
+    `planUID`               BIGINT UNSIGNED     NOT NULL
+        COMMENT 'FK to tblPricePlans.planUID — the exact plan subscribed',
+    `priceAtSubscription`   DECIMAL(10, 2)      NOT NULL
+        COMMENT 'GRANDFATHER PIN: the per-interval amount agreed at purchase',
+    `currencyAtSubscription` CHAR(3)            NOT NULL DEFAULT 'GBP'
+        COMMENT 'Currency of the pinned price (ISO 4217)',
+    `seats`                 SMALLINT UNSIGNED   DEFAULT NULL
+        COMMENT 'Purchased seat count for per-seat plans (NULL = per-org plan)',
+    `perSeatPriceAtSubscription` DECIMAL(10, 2) DEFAULT NULL
+        COMMENT 'GRANDFATHER PIN for the per-seat component (NULL = plan had none)',
+    `capAmountAtSubscription` DECIMAL(10, 2)    DEFAULT NULL
+        COMMENT 'GRANDFATHER PIN for a payg_capped cap',
+    `isCurrent`             TINYINT(1) UNSIGNED NOT NULL DEFAULT 1
+        COMMENT '1 = the active plan row for this subscription; plan changes close the old row and insert a new one',
+    `effectiveFrom`         DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP
+        COMMENT 'When this plan attachment began',
+    `effectiveUntil`        DATETIME            DEFAULT NULL
+        COMMENT 'When it ended (NULL while current)',
+    `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`             DATETIME            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`subscriptionPlanUID`),
+    INDEX `IDX_subplan_subscription` (`subscriptionUID`, `isCurrent`),
+    INDEX `IDX_subplan_plan` (`planUID`),
+    CONSTRAINT `FK_subplan_subscription`
+        FOREIGN KEY (`subscriptionUID`)
+        REFERENCES `tblSubscriptions` (`subscriptionUID`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+    CONSTRAINT `FK_subplan_plan`
+        FOREIGN KEY (`planUID`)
+        REFERENCES `tblPricePlans` (`planUID`)
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Attaches price-plan context (with grandfather price pins and plan history) to unmodified tblSubscriptions rows';
+
+-- 8. tblUsageCounters — aggregated usage metering (see schema 036 §8)
+CREATE TABLE IF NOT EXISTS `tblUsageCounters` (
+    `counterUID`            BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT
+        COMMENT 'Unique row identifier',
+    `orgHandle`             VARCHAR(50)         NOT NULL
+        COMMENT 'FK to tblOrganisations.orgHandle',
+    `featureUID`            BIGINT UNSIGNED     NOT NULL
+        COMMENT 'FK to tblFeatures.featureUID — must be an isMeterable feature',
+    `periodType`            ENUM('day', 'month', 'billing_period')
+                            NOT NULL DEFAULT 'month'
+        COMMENT 'Aggregation window kind',
+    `periodStart`           DATE                NOT NULL
+        COMMENT 'First day of the window',
+    `usedCount`             BIGINT UNSIGNED     NOT NULL DEFAULT 0
+        COMMENT 'Units consumed in this window (atomic UPSERT)',
+    `lastEventAt`           DATETIME            DEFAULT NULL
+        COMMENT 'Timestamp of the most recent metered event',
+    `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`             DATETIME            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`counterUID`),
+    UNIQUE KEY `UQ_usage_counter` (`orgHandle`, `featureUID`, `periodType`, `periodStart`),
+    INDEX `IDX_usage_feature_period` (`featureUID`, `periodType`, `periodStart`),
+    CONSTRAINT `FK_usage_counter_org`
+        FOREIGN KEY (`orgHandle`)
+        REFERENCES `tblOrganisations` (`orgHandle`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+    CONSTRAINT `FK_usage_counter_feature`
+        FOREIGN KEY (`featureUID`)
+        REFERENCES `tblFeatures` (`featureUID`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Aggregated per-org usage counters per meterable feature and period — powers quotas, PAYG billing, and PAYG caps';
+
+-- 9. tblUsageCredits — purchased/granted unit credits (see schema 036 §9)
+CREATE TABLE IF NOT EXISTS `tblUsageCredits` (
+    `creditUID`             BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT
+        COMMENT 'Unique row identifier',
+    `orgHandle`             VARCHAR(50)         NOT NULL
+        COMMENT 'FK to tblOrganisations.orgHandle',
+    `featureUID`            BIGINT UNSIGNED     NOT NULL
+        COMMENT 'FK to tblFeatures.featureUID — the meterable feature these credits apply to',
+    `unitsGranted`          BIGINT UNSIGNED     NOT NULL
+        COMMENT 'Units in the bucket at purchase/grant time',
+    `unitsRemaining`        BIGINT UNSIGNED     NOT NULL
+        COMMENT 'Units left (decremented as usage draws down)',
+    `sourcePlanUID`         BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'FK to tblPricePlans.planUID of the credit_pack purchased (NULL for goodwill/referral grants)',
+    `sourcePaymentUID`      BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'FK to tblPayments.paymentUID that bought this bucket (NULL for grants)',
+    `expiresAt`             DATETIME            DEFAULT NULL
+        COMMENT 'When unused credits lapse (NULL = never)',
+    `notes`                 VARCHAR(255)        DEFAULT NULL
+        COMMENT 'Audit note (e.g. "referral reward", ticket ref)',
+    `isActive`              TINYINT(1) UNSIGNED NOT NULL DEFAULT 1
+        COMMENT 'Soft disable without losing the audit row',
+    `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`             DATETIME            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`creditUID`),
+    INDEX `IDX_credit_org_feature` (`orgHandle`, `featureUID`, `isActive`, `expiresAt`),
+    CONSTRAINT `FK_credit_org`
+        FOREIGN KEY (`orgHandle`)
+        REFERENCES `tblOrganisations` (`orgHandle`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+    CONSTRAINT `FK_credit_feature`
+        FOREIGN KEY (`featureUID`)
+        REFERENCES `tblFeatures` (`featureUID`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+    CONSTRAINT `FK_credit_source_plan`
+        FOREIGN KEY (`sourcePlanUID`)
+        REFERENCES `tblPricePlans` (`planUID`)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL,
+    CONSTRAINT `FK_credit_source_payment`
+        FOREIGN KEY (`sourcePaymentUID`)
+        REFERENCES `tblPayments` (`paymentUID`)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Prepaid metered-unit buckets (credit packs, referral/goodwill grants) drawn down before PAYG charging';
+
+-- 10. tblUsageEvents — optional fine-grained usage ledger (see schema 036 §10)
+CREATE TABLE IF NOT EXISTS `tblUsageEvents` (
+    `eventUID`              BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT
+        COMMENT 'Unique row identifier',
+    `orgHandle`             VARCHAR(50)         NOT NULL
+        COMMENT 'FK to tblOrganisations.orgHandle',
+    `featureUID`            BIGINT UNSIGNED     NOT NULL
+        COMMENT 'FK to tblFeatures.featureUID — the metered dimension',
+    `quantity`              INT UNSIGNED        NOT NULL DEFAULT 1
+        COMMENT 'Units consumed by this event (bulk API call may consume many)',
+    `eventRef`              VARCHAR(100)        DEFAULT NULL
+        COMMENT 'Caller-supplied idempotency reference',
+    `contextJSON`           JSON                DEFAULT NULL
+        COMMENT 'Optional event context for audit',
+    `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`eventUID`),
+    UNIQUE KEY `UQ_usage_event_ref` (`featureUID`, `eventRef`),
+    INDEX `IDX_usage_event_org` (`orgHandle`, `featureUID`, `createdAt`),
+    INDEX `IDX_usage_event_created` (`createdAt`),
+    CONSTRAINT `FK_usage_event_org`
+        FOREIGN KEY (`orgHandle`)
+        REFERENCES `tblOrganisations` (`orgHandle`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+    CONSTRAINT `FK_usage_event_feature`
+        FOREIGN KEY (`featureUID`)
+        REFERENCES `tblFeatures` (`featureUID`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Optional fine-grained usage event ledger for PAYG audit/disputes — counters remain the operational metering source';
+
+-- 11. Verification view (see schema 036 §11)
+CREATE OR REPLACE VIEW `vwSubscriptionTierEntitlements` AS
+SELECT
+    tf.`tierID` AS `tierID`,
+    MAX(CASE WHEN f.`featureSlug` = 'links.max'
+             THEN CASE WHEN tf.`isUnlimited` = 1 THEN NULL ELSE tf.`valueInt` END END) AS `maxLinks`,
+    MAX(CASE WHEN f.`featureSlug` = 'domains.custom_max'
+             THEN CASE WHEN tf.`isUnlimited` = 1 THEN NULL ELSE tf.`valueInt` END END) AS `maxCustomDomains`,
+    MAX(CASE WHEN f.`featureSlug` = 'api.requests_per_day'
+             THEN CASE WHEN tf.`isUnlimited` = 1 THEN NULL ELSE tf.`valueInt` END END) AS `maxAPIRequestsPerDay`,
+    MAX(CASE WHEN f.`featureSlug` = 'linkspage.pages_max'
+             THEN CASE WHEN tf.`isUnlimited` = 1 THEN NULL ELSE tf.`valueInt` END END) AS `maxLinksPages`,
+    MAX(CASE WHEN f.`featureSlug` = 'redirects.advanced'  THEN tf.`valueBoolean` END) AS `hasAdvancedRedirects`,
+    MAX(CASE WHEN f.`featureSlug` = 'analytics.enabled'   THEN tf.`valueBoolean` END) AS `hasAnalytics`,
+    MAX(CASE WHEN f.`featureSlug` = 'qr.dynamic'          THEN tf.`valueBoolean` END) AS `hasQRCodes`,
+    MAX(CASE WHEN f.`featureSlug` = 'api.access'          THEN tf.`valueBoolean` END) AS `hasAPIAccess`,
+    MAX(CASE WHEN f.`featureSlug` = 'support.priority'    THEN tf.`valueBoolean` END) AS `hasPrioritySupport`,
+    MAX(CASE WHEN f.`featureSlug` = 'linkspage.custom_html' THEN tf.`valueBoolean` END) AS `hasCustomHTML`
+FROM `tblTierFeatures` tf
+INNER JOIN `tblFeatures` f
+        ON f.`featureUID` = tf.`featureUID`
+       AND f.`isActive`   = 1
+WHERE (tf.`effectiveFrom`  IS NULL OR tf.`effectiveFrom`  <= NOW())
+  AND (tf.`effectiveUntil` IS NULL OR tf.`effectiveUntil` >  NOW())
+GROUP BY tf.`tierID`;
+
+-- =============================================================================
+-- PART 2 — SEED DATA (verbatim from web/_sql/seeds/018_pricing_feature_registry.sql
+-- and web/_sql/seeds/019_pricing_settings.sql).
+-- =============================================================================
+
+-- 2a. Feature-registry rows replacing the legacy hard-coded columns
+INSERT INTO `tblFeatures` (
+    `featureSlug`, `featureName`, `featureDescription`,
+    `valueType`, `valueUnit`, `quotaPeriod`,
+    `defaultValueBoolean`, `defaultValueInt`, `defaultIsUnlimited`,
+    `category`, `isMeterable`, `legacyColumn`, `sortOrder`, `isActive`
+) VALUES
+('links.max', 'Active short links', 'Maximum simultaneously active short URLs for the organisation.',
+ 'limit', 'links', NULL, NULL, 0, 0, 'links', 1, 'maxLinks', 10, 1),
+('domains.custom_max', 'Custom short domains', 'Maximum ownership-verified custom short domains.',
+ 'limit', 'domains', NULL, NULL, 0, 0, 'domains', 0, 'maxCustomDomains', 10, 1),
+('api.requests_per_day', 'API requests per day', 'Daily API request allowance across the organisation''s keys.',
+ 'quota', 'requests', 'day', NULL, 0, 0, 'api', 1, 'maxAPIRequestsPerDay', 20, 1),
+('linkspage.pages_max', 'LinksPages', 'Maximum LinksPage (link-in-bio) pages.',
+ 'limit', 'pages', NULL, NULL, 0, 0, 'linkspage', 0, 'maxLinksPages', 10, 1),
+('redirects.advanced', 'Advanced redirects (umbrella)', 'Legacy umbrella flag for scheduled/device/geo/age-gate redirects. Superseded by the granular redirects.* flags; resolver reports it ON when ANY granular redirect flag is ON.',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'redirects', 0, 'hasAdvancedRedirects', 5, 1),
+('analytics.enabled', 'Analytics dashboard', 'Org-scoped click/human/bot/unique-IP analytics dashboard.',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'analytics', 0, 'hasAnalytics', 10, 1),
+('qr.dynamic', 'Dynamic QR codes', 'CueRCode dynamic-QR integration (re-pointable codes).',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'qr', 0, 'hasQRCodes', 10, 1),
+('api.access', 'API access', 'Public API v1 access (key auth, scopes).',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'api', 0, 'hasAPIAccess', 10, 1),
+('support.priority', 'Priority support', 'Priority support queue.',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'support', 0, 'hasPrioritySupport', 10, 1),
+('linkspage.custom_html', 'LinksPage custom HTML/CSS', 'High-risk premium feature: free-form custom HTML/CSS on LinksPages (Component C.6, #49). Also governed by the linkspage.custom_html_enabled kill-switch.',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'linkspage', 0, 'hasCustomHTML', 40, 1)
+ON DUPLICATE KEY UPDATE
+    `featureDescription` = VALUES(`featureDescription`);
+
+-- 2b. New granular registry rows (no legacy column)
+INSERT INTO `tblFeatures` (
+    `featureSlug`, `featureName`, `featureDescription`,
+    `valueType`, `valueUnit`, `quotaPeriod`,
+    `defaultValueBoolean`, `defaultValueInt`, `defaultIsUnlimited`,
+    `category`, `isMeterable`, `legacyColumn`, `sortOrder`, `isActive`
+) VALUES
+('links.custom_alias', 'Custom aliases', 'Choose custom short-link aliases.',
+ 'boolean', NULL, NULL, 1, NULL, 0, 'links', 0, NULL, 20, 1),
+('redirects.scheduled', 'Scheduled redirects', 'Time-window destination switching (schema 021).',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'redirects', 0, NULL, 10, 1),
+('redirects.device', 'Device-based redirects', 'Destination by device class (schema 021).',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'redirects', 0, NULL, 20, 1),
+('redirects.geo', 'Geo-based redirects', 'Destination by visitor country (schema 021).',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'redirects', 0, NULL, 30, 1),
+('redirects.agegate', 'Age-gate redirects', 'Age-verification interstitial before redirect (schema 021).',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'redirects', 0, NULL, 40, 1),
+('analytics.retention_days', 'Analytics retention', 'How many days of analytics history are visible.',
+ 'limit', 'days', NULL, NULL, 30, 0, 'analytics', 0, NULL, 20, 1),
+('analytics.export_csv', 'CSV export', 'Analytics CSV export.',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'analytics', 0, NULL, 30, 1),
+('analytics.geo_country', 'Country geolocation', 'Country-level click geolocation (MaxMind, gated).',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'analytics', 0, NULL, 40, 1),
+('api.bulk_endpoints', 'Bulk API endpoints', 'Bulk create/update API endpoints.',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'api', 0, NULL, 30, 1),
+('qr.scan_attribution', 'QR scan attribution', 'Scan-source attribution analytics for dynamic QR codes.',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'qr', 0, NULL, 20, 1),
+('linkspage.all_templates', 'All LinksPage templates', 'Access to the full system template library (vs starter subset).',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'linkspage', 0, NULL, 20, 1),
+('linkspage.custom_domain', 'LinksPage custom domain', 'Serve a LinksPage on a verified custom domain.',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'linkspage', 0, NULL, 30, 1),
+('linkspage.agegate', 'LinksPage age verification', 'Age-verification gate on LinksPages.',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'linkspage', 0, NULL, 50, 1),
+('org.seats', 'Team seats', 'Maximum users per organisation.',
+ 'limit', 'seats', NULL, NULL, 1, 0, 'org', 0, NULL, 10, 1),
+('clicks.tracked_per_month', 'Tracked clicks per month', 'Metering dimension for click-based PAYG (not gated at launch).',
+ 'quota', 'clicks', 'month', NULL, NULL, 1, 'analytics', 1, NULL, 50, 1),
+('qr.scans_per_month', 'QR scans per month', 'Metering dimension for scan-based PAYG (not gated at launch).',
+ 'quota', 'scans', 'month', NULL, NULL, 1, 'qr', 1, NULL, 30, 1)
+ON DUPLICATE KEY UPDATE
+    `featureDescription` = VALUES(`featureDescription`);
+
+-- 2c. Backfill tblTierFeatures from the legacy hard-coded columns
+INSERT INTO `tblTierFeatures` (`tierID`, `featureUID`, `valueInt`, `isUnlimited`)
+SELECT t.`tierID`, f.`featureUID`, t.`maxLinks`,
+       CASE WHEN t.`maxLinks` IS NULL THEN 1 ELSE 0 END
+FROM   `tblSubscriptionTiers` t
+JOIN   `tblFeatures` f ON f.`legacyColumn` = 'maxLinks'
+ON DUPLICATE KEY UPDATE `tierFeatureUID` = `tblTierFeatures`.`tierFeatureUID`;
+
+INSERT INTO `tblTierFeatures` (`tierID`, `featureUID`, `valueInt`, `isUnlimited`)
+SELECT t.`tierID`, f.`featureUID`, t.`maxCustomDomains`,
+       CASE WHEN t.`maxCustomDomains` IS NULL THEN 1 ELSE 0 END
+FROM   `tblSubscriptionTiers` t
+JOIN   `tblFeatures` f ON f.`legacyColumn` = 'maxCustomDomains'
+ON DUPLICATE KEY UPDATE `tierFeatureUID` = `tblTierFeatures`.`tierFeatureUID`;
+
+INSERT INTO `tblTierFeatures` (`tierID`, `featureUID`, `valueInt`, `isUnlimited`)
+SELECT t.`tierID`, f.`featureUID`, t.`maxAPIRequestsPerDay`,
+       CASE WHEN t.`maxAPIRequestsPerDay` IS NULL THEN 1 ELSE 0 END
+FROM   `tblSubscriptionTiers` t
+JOIN   `tblFeatures` f ON f.`legacyColumn` = 'maxAPIRequestsPerDay'
+ON DUPLICATE KEY UPDATE `tierFeatureUID` = `tblTierFeatures`.`tierFeatureUID`;
+
+INSERT INTO `tblTierFeatures` (`tierID`, `featureUID`, `valueInt`, `isUnlimited`)
+SELECT t.`tierID`, f.`featureUID`, t.`maxLinksPages`,
+       CASE WHEN t.`maxLinksPages` IS NULL THEN 1 ELSE 0 END
+FROM   `tblSubscriptionTiers` t
+JOIN   `tblFeatures` f ON f.`legacyColumn` = 'maxLinksPages'
+ON DUPLICATE KEY UPDATE `tierFeatureUID` = `tblTierFeatures`.`tierFeatureUID`;
+
+INSERT INTO `tblTierFeatures` (`tierID`, `featureUID`, `valueBoolean`)
+SELECT t.`tierID`, f.`featureUID`, t.`hasAdvancedRedirects`
+FROM   `tblSubscriptionTiers` t
+JOIN   `tblFeatures` f ON f.`legacyColumn` = 'hasAdvancedRedirects'
+ON DUPLICATE KEY UPDATE `tierFeatureUID` = `tblTierFeatures`.`tierFeatureUID`;
+
+INSERT INTO `tblTierFeatures` (`tierID`, `featureUID`, `valueBoolean`)
+SELECT t.`tierID`, f.`featureUID`, t.`hasAnalytics`
+FROM   `tblSubscriptionTiers` t
+JOIN   `tblFeatures` f ON f.`legacyColumn` = 'hasAnalytics'
+ON DUPLICATE KEY UPDATE `tierFeatureUID` = `tblTierFeatures`.`tierFeatureUID`;
+
+INSERT INTO `tblTierFeatures` (`tierID`, `featureUID`, `valueBoolean`)
+SELECT t.`tierID`, f.`featureUID`, t.`hasQRCodes`
+FROM   `tblSubscriptionTiers` t
+JOIN   `tblFeatures` f ON f.`legacyColumn` = 'hasQRCodes'
+ON DUPLICATE KEY UPDATE `tierFeatureUID` = `tblTierFeatures`.`tierFeatureUID`;
+
+INSERT INTO `tblTierFeatures` (`tierID`, `featureUID`, `valueBoolean`)
+SELECT t.`tierID`, f.`featureUID`, t.`hasAPIAccess`
+FROM   `tblSubscriptionTiers` t
+JOIN   `tblFeatures` f ON f.`legacyColumn` = 'hasAPIAccess'
+ON DUPLICATE KEY UPDATE `tierFeatureUID` = `tblTierFeatures`.`tierFeatureUID`;
+
+INSERT INTO `tblTierFeatures` (`tierID`, `featureUID`, `valueBoolean`)
+SELECT t.`tierID`, f.`featureUID`, t.`hasPrioritySupport`
+FROM   `tblSubscriptionTiers` t
+JOIN   `tblFeatures` f ON f.`legacyColumn` = 'hasPrioritySupport'
+ON DUPLICATE KEY UPDATE `tierFeatureUID` = `tblTierFeatures`.`tierFeatureUID`;
+
+INSERT INTO `tblTierFeatures` (`tierID`, `featureUID`, `valueBoolean`)
+SELECT t.`tierID`, f.`featureUID`, t.`hasCustomHTML`
+FROM   `tblSubscriptionTiers` t
+JOIN   `tblFeatures` f ON f.`legacyColumn` = 'hasCustomHTML'
+ON DUPLICATE KEY UPDATE `tierFeatureUID` = `tblTierFeatures`.`tierFeatureUID`;
+
+-- 2d. Engine-switch settings (ALL seeded OFF except the two display defaults)
+INSERT INTO `tblSettings` (
+    `settingID`, `settingScope`, `settingScopeRef`,
+    `settingValue`, `settingDefault`, `settingDescription`,
+    `settingDataType`, `isSensitive`, `isEditable`
+) VALUES
+('billing.pricing_engine_enabled', 'System', NULL,
+ '0', '0', 'MASTER SWITCH for the flexible pricing/entitlement engine. OFF (0) = entitlements.php resolves tiers from the legacy tblSubscriptionTiers has*/max* columns exactly as before — the new tables are completely inert. ON (1) = web/_functions/pricing.php resolves entitlements from tblFeatures + tblTierFeatures + tblOrgFeatureOverrides (fail-open contract preserved).',
+ 'boolean', 0, 1),
+('billing.payg_enabled', 'System', NULL,
+ '0', '0', 'Enables pay-as-you-go and PAYG-capped price plans (planType payg / payg_capped). OFF by default — requires usage metering proven in production first.',
+ 'boolean', 0, 1),
+('billing.usage_metering_enabled', 'System', NULL,
+ '0', '0', 'Enables writing usage to tblUsageCounters (and, when event logging is also on, tblUsageEvents). Can run ON ahead of PAYG launch to gather baseline usage with no billing effect.',
+ 'boolean', 0, 1),
+('billing.usage_event_log_enabled', 'System', NULL,
+ '0', '0', 'Enables the fine-grained tblUsageEvents audit ledger in addition to counters. Independent of counter metering; counters alone are sufficient for quotas and PAYG maths.',
+ 'boolean', 0, 1),
+('billing.usage_event_retention_days', 'System', NULL,
+ '90', '90', 'How many days of tblUsageEvents rows to retain; older rows are swept by a probabilistic (1-in-100 request) prune, mirroring api.request_log_retention_days.',
+ 'integer', 0, 1),
+('billing.lifetime_plans_enabled', 'System', NULL,
+ '0', '0', 'Enables offering lifetime price plans (planType lifetime). OFF by default pending owner decision on founding-member deals.',
+ 'boolean', 0, 1),
+('billing.coupon_stacking_enabled', 'System', NULL,
+ '0', '0', 'Master permission for combining multiple coupons on one purchase (per-coupon isStackable/stackingGroup still apply). OFF = one coupon per purchase, full stop.',
+ 'boolean', 0, 1),
+('billing.default_currency', 'System', NULL,
+ 'GBP', 'GBP', 'Default ISO 4217 currency for the price book and pricing page.',
+ 'string', 0, 1),
+('billing.default_region', 'System', NULL,
+ 'GB', 'GB', 'Default region code used to select regional price-plan variants when no better match applies.',
+ 'string', 0, 1)
+ON DUPLICATE KEY UPDATE
+    `settingDescription` = VALUES(`settingDescription`);
+
+-- =============================================================================
+-- Verification (informational — safe to run, changes nothing).
+-- =============================================================================
+-- After this migration, every seeded tier's legacy columns must match the
+-- verification view column-for-column; this SELECT should return rows where
+-- every diff* column is 0 (see tests/integration/pricing_backfill_verify.php
+-- for the automated version of this check).
+SELECT
+    t.`tierID`,
+    (t.`maxLinks` <=> v.`maxLinks`)                         AS `maxLinksMatches`,
+    (t.`maxCustomDomains` <=> v.`maxCustomDomains`)         AS `maxCustomDomainsMatches`,
+    (t.`maxAPIRequestsPerDay` <=> v.`maxAPIRequestsPerDay`) AS `maxAPIRequestsPerDayMatches`,
+    (t.`maxLinksPages` <=> v.`maxLinksPages`)                AS `maxLinksPagesMatches`,
+    (t.`hasAdvancedRedirects` <=> v.`hasAdvancedRedirects`)  AS `hasAdvancedRedirectsMatches`,
+    (t.`hasAnalytics` <=> v.`hasAnalytics`)                   AS `hasAnalyticsMatches`,
+    (t.`hasQRCodes` <=> v.`hasQRCodes`)                       AS `hasQRCodesMatches`,
+    (t.`hasAPIAccess` <=> v.`hasAPIAccess`)                   AS `hasAPIAccessMatches`,
+    (t.`hasPrioritySupport` <=> v.`hasPrioritySupport`)       AS `hasPrioritySupportMatches`,
+    (t.`hasCustomHTML` <=> v.`hasCustomHTML`)                 AS `hasCustomHTMLMatches`
+FROM `tblSubscriptionTiers` t
+LEFT JOIN `vwSubscriptionTierEntitlements` v USING (`tierID`);
+
+-- End of file.

--- a/web/_sql/schema/036_pricing_engine.sql
+++ b/web/_sql/schema/036_pricing_engine.sql
@@ -1,0 +1,1137 @@
+-- Copyright (c) 2024–2026 MWBM Partners Ltd (MWservices).
+-- All rights reserved.
+--
+-- This source code is proprietary and confidential.
+-- Unauthorised copying, modification, or distribution is strictly prohibited.
+
+-- =============================================================================
+-- Go2My.Link — Flexible Pricing & Entitlement Engine — Tables + Verification View
+-- =============================================================================
+-- WHAT THIS IS
+-- ------------
+-- A fully data-driven replacement for the HARD-CODED entitlement columns on
+-- tblSubscriptionTiers (maxLinks, maxCustomDomains, maxAPIRequestsPerDay,
+-- maxLinksPages, hasAdvancedRedirects, hasAnalytics, hasQRCodes, hasAPIAccess,
+-- hasPrioritySupport, hasCustomHTML) and the 2-value discountType ENUM on
+-- tblPaymentDiscounts. After this schema:
+--
+--   * Adding a FEATURE          = INSERT one row into tblFeatures.
+--   * Adding a TIER             = INSERT into tblSubscriptionTiers (unchanged)
+--                                 + rows in tblTierFeatures.
+--   * Adding a PRICE STRUCTURE  = INSERT one row into tblPricePlans
+--                                 (recurring / lifetime / one-off / PAYG /
+--                                  PAYG-capped / add-on / credit pack, any
+--                                  currency, any region, any validity window).
+--   * A custom deal for one org = INSERT one row into tblOrgFeatureOverrides.
+--
+--   NO schema change is ever needed again for tiers, features, or prices.
+--
+-- COMPATIBILITY GUARANTEES (non-negotiable)
+-- -----------------------------------------
+--   1. 100% ADDITIVE. No existing table is ALTERed, dropped, or rewritten.
+--      tblSubscriptionTiers keeps its columns (they remain the LEGACY read
+--      path and stay authoritative while the engine is OFF).
+--   2. tblSubscriptions / tblPayments / tblPaymentDiscounts are untouched.
+--      These new tables REFERENCE them; nothing changes their shape or
+--      semantics.
+--   3. DISABLED BY DEFAULT. The resolver in web/_functions/pricing.php only
+--      activates when tblSettings 'billing.pricing_engine_enabled' = '1'
+--      (seeded '0' in web/_sql/seeds/019_pricing_settings.sql). Until then,
+--      entitlements.php behaves EXACTLY as before this file was added, byte
+--      for byte. Every table below is inert data until that flag flips.
+--   4. entitlements.php's public API is PRESERVED: g2ml_getOrgTier(),
+--      g2ml_canUseFeature(), g2ml_checkLimit(), the two whitelist constants,
+--      and the FAIL-OPEN contract all keep their exact signatures/behaviour.
+--
+-- LOAD-ORDER SAFETY
+-- -----------------
+-- This file loads AFTER 011 (tblSubscriptionTiers), 012 (tblOrganisations),
+-- 013 (tblUsers), and 033 (tblSubscriptions/tblPaymentDiscounts/tblPayments),
+-- so every FK target below already exists. WITHIN this file, tables are
+-- ordered so every FK resolves during a clean import with
+-- foreign_key_checks = 1:
+--
+--    1. tblFeatures            (no deps on new tables)
+--    2. tblPricePlans          (FK → tblFeatures, tblSubscriptionTiers, self)
+--    3. tblTierFeatures        (FK → tblFeatures, tblSubscriptionTiers)
+--    4. tblOrgFeatureOverrides (FK → tblFeatures, tblOrganisations, tblUsers,
+--                                    tblPricePlans)
+--    5. tblCoupons             (FK → tblPricePlans, tblSubscriptionTiers,
+--                                    tblPaymentDiscounts)
+--    6. tblCouponRedemptions   (FK → tblCoupons, tblOrganisations,
+--                                    tblSubscriptions, tblPayments)
+--    7. tblSubscriptionPlans   (FK → tblSubscriptions, tblPricePlans)
+--    8. tblUsageCounters       (FK → tblOrganisations, tblFeatures)
+--    9. tblUsageCredits        (FK → tblOrganisations, tblFeatures, tblPricePlans)
+--   10. tblUsageEvents         (FK → tblOrganisations, tblFeatures)
+--   11. vwSubscriptionTierEntitlements (verification view, reads tables above)
+--
+-- The feature-registry seed + legacy backfill (INSERT…SELECT from
+-- tblSubscriptionTiers' has*/max* columns into tblTierFeatures) lives in
+-- web/_sql/seeds/018_pricing_feature_registry.sql — it runs AFTER this file
+-- and AFTER the tier seed (001_subscription_tiers.sql) so the JOIN has rows to
+-- copy. The nine billing.* engine-switch settings (all seeded OFF) live in
+-- web/_sql/seeds/019_pricing_settings.sql. All CREATEs here use IF NOT EXISTS
+-- and all seed INSERTs are idempotent, so re-running the whole set is safe —
+-- the same property lets web/_sql/migrations/020_pricing_engine.sql reuse this
+-- content verbatim for already-deployed databases.
+--
+-- HOW entitlements.php READS THIS MODEL (resolver contract — implemented in
+-- web/_functions/pricing.php; see that file's header and the guarded hook in
+-- _g2ml_resolveOrgTier()):
+--
+--   PUBLIC SIGNATURES PRESERVED (unchanged, callers untouched):
+--     g2ml_getOrgTier(string $orgHandle): array
+--     g2ml_canUseFeature(string $orgHandle, string $flag): bool
+--     g2ml_checkLimit(string $orgHandle, string $limit, int $currentCount): array
+--     constants G2ML_ENTITLEMENT_FEATURE_FLAGS / G2ML_ENTITLEMENT_LIMIT_FIELDS
+--
+--   HOOK POINT: inside _g2ml_resolveOrgTier(), AFTER the '[default]'-org and
+--   GlobalAdmin sentinel branches (those short-circuit exactly as today), and
+--   BEFORE the legacy JOIN lookup — only when pricing.php is loaded AND
+--   getSetting('billing.pricing_engine_enabled', '0') === '1'. Any failure
+--   (false/non-array) falls through to the legacy path (fail OPEN to the OLD
+--   behaviour, never to a block). With the setting at its seeded '0' value
+--   this hook is dead code — current behaviour is preserved byte-for-byte.
+--
+--   RESOLUTION (g2ml_pricingResolveOrgTier), all reads prepared-statement
+--   MySQLi, every failure returning false so the caller falls back:
+--     1. org → tierID via tblOrganisations (as today; inactive/missing tier →
+--        lowest-sortOrder ACTIVE tier fallback, as today).
+--     2. Load ACTIVE tblFeatures (request-cached; one small table scan).
+--     3. Load the tier's CURRENTLY-EFFECTIVE tblTierFeatures rows (latest
+--        effectiveFrom <= NOW(), effectiveUntil NULL or > NOW()).
+--     4. Load the org's ACTIVE, currently-effective tblOrgFeatureOverrides.
+--     5. MERGE per feature: safe-floor default (tblFeatures.default*) → tier
+--        value → override ('deny' forces off; 'grant' forces on; 'set'
+--        replaces incl. isUnlimited; 'adjust' adds adjustDelta to the numeric
+--        value, floored at 0; multiple 'adjust' rows accumulate).
+--     6. EMIT the legacy-shaped array (tierID, tierName, maxLinks,
+--        maxCustomDomains, maxAPIRequestsPerDay, maxLinksPages, has*-flags,
+--        unlimited, source='pricing_engine') using tblFeatures.legacyColumn as
+--        the mapping; isUnlimited=1 → NULL (legacy unlimited semantics);
+--        hasAdvancedRedirects = umbrella row OR any granular redirects.* on.
+--        Granular slugs are ADDITIONALLY exposed under a 'features' sub-array
+--        for new callers (g2ml_pricingCanUse()/g2ml_pricingGetLimit()) —
+--        legacy keys stay primitive so existing callers notice nothing.
+--   FAIL-OPEN: any DB/system error at steps 1–5 → return false → caller falls
+--   back to the legacy resolver, which itself fails open to the unlimited
+--   sentinel — strictly no new blocking failure mode.
+--
+-- @package    Go2My.Link
+-- @subpackage Database
+-- @author     MWBM Partners Ltd (MWservices)
+-- @version    1.0.0
+-- @since      v1.6.0 — Pricing Engine phase (scaffold — all tables inert until
+--             billing.pricing_engine_enabled is switched on)
+--
+-- 📖 References:
+--     - Legacy tier columns:   web/_sql/schema/011_core_subscription_tiers.sql
+--     - Legacy discounts:      web/_sql/schema/033_payments.sql (tblPaymentDiscounts)
+--     - Read API to preserve:  web/_functions/entitlements.php
+--     - Resolver:              web/_functions/pricing.php
+--     - Feature/backfill seed: web/_sql/seeds/018_pricing_feature_registry.sql
+--     - Engine-switch seed:    web/_sql/seeds/019_pricing_settings.sql
+--     - Already-deployed DBs:  web/_sql/migrations/020_pricing_engine.sql
+--     - Strategy rationale:    Pricing_Strategy.md (repo root)
+-- =============================================================================
+
+USE `mwtools_Go2MyLink`;
+
+-- =============================================================================
+-- 1. tblFeatures — THE FEATURE REGISTRY
+-- =============================================================================
+-- Flexibility requirement satisfied: "Adding a feature = a row, never a schema
+-- change." Every gateable capability — boolean flags, numeric limits, metered
+-- quotas, enum choices, structured config — is ONE row here, identified by a
+-- stable dot-namespaced slug (e.g. 'links.max', 'redirects.geo').
+--
+-- valueType semantics:
+--   'boolean' — on/off entitlement            (uses *Boolean value columns)
+--   'limit'   — standing cap on a COUNT of things that exist
+--               (active links, domains, pages, seats)   (uses *Int columns)
+--   'quota'   — consumable allowance per period (API req/day, clicks/month)
+--               (uses *Int columns + quotaPeriod; meterable for PAYG)
+--   'enum'    — one-of-N choice (e.g. support level)    (uses *String columns;
+--               allowed values listed in allowedValues, newline-separated,
+--               mirroring tblSettings.settingValuesAllowed)
+--   'config'  — structured JSON entitlement (e.g. per-template allowances)
+--               (uses *JSON columns)
+--
+-- isMeterable = 1 marks a feature as a legal PAYG metering dimension: a
+-- tblPricePlans row may point its meteredFeatureUID here, and tblUsageCounters
+-- accumulates consumption against it. Adding a NEW metering dimension (QR
+-- scans, LinksPage views, …) = flipping/adding a row — no schema change.
+--
+-- legacyColumn maps a registry row back to the hard-coded
+-- tblSubscriptionTiers column it replaces — this drives the automated
+-- backfill (seed 018) AND lets the resolver emit the legacy-shaped tier array
+-- entitlements.php callers expect. NULL for brand-new granular features.
+--
+-- Default-value columns are the SAFE FLOOR used when a tier simply has no
+-- tblTierFeatures row for a feature (e.g. a feature added after a tier was
+-- configured): the resolver falls back to these — which default to
+-- "off"/0/not-unlimited — so a forgotten mapping can never accidentally grant
+-- a premium capability.
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS `tblFeatures` (
+    `featureUID`            BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT
+        COMMENT 'Unique row identifier',
+
+    `featureSlug`           VARCHAR(100)        NOT NULL
+        COMMENT 'Stable dot-namespaced identifier (e.g. links.max, redirects.geo, api.requests_per_day). NEVER renamed once live — display text changes go in featureName.',
+
+    `featureName`           VARCHAR(150)        NOT NULL
+        COMMENT 'Human-readable name for admin UI / pricing page rows',
+
+    `featureDescription`    TEXT                DEFAULT NULL
+        COMMENT 'What this feature gates, for admin UI and pricing-page tooltips',
+
+    `valueType`             ENUM('boolean', 'limit', 'quota', 'enum', 'config')
+                            NOT NULL DEFAULT 'boolean'
+        COMMENT 'How entitlement values for this feature are typed and enforced (see header)',
+
+    `valueUnit`             VARCHAR(50)         DEFAULT NULL
+        COMMENT 'Display/metering unit for limit/quota types (e.g. links, domains, requests, days)',
+
+    `quotaPeriod`           ENUM('day', 'month', 'billing_period')
+                            DEFAULT NULL
+        COMMENT 'For valueType=quota only: the window the allowance renews over (NULL otherwise)',
+
+    `allowedValues`         TEXT                DEFAULT NULL
+        COMMENT 'For valueType=enum only: newline-separated permitted values (mirrors tblSettings.settingValuesAllowed idiom); NULL = not applicable',
+
+    `defaultValueBoolean`   TINYINT(1) UNSIGNED DEFAULT NULL
+        COMMENT 'Safe-floor default for boolean features when a tier has no row (normally 0 = off)',
+
+    `defaultValueInt`       BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'Safe-floor default for limit/quota features when a tier has no row (normally 0)',
+
+    `defaultValueString`    VARCHAR(255)        DEFAULT NULL
+        COMMENT 'Safe-floor default for enum features when a tier has no row',
+
+    `defaultValueJSON`      JSON                DEFAULT NULL
+        COMMENT 'Safe-floor default for config features when a tier has no row',
+
+    `defaultIsUnlimited`    TINYINT(1) UNSIGNED NOT NULL DEFAULT 0
+        COMMENT 'Whether the safe-floor default is "unlimited" (1) — kept EXPLICIT rather than overloading NULL, so "no value configured" can never be misread as "unlimited"',
+
+    `category`              VARCHAR(50)         NOT NULL DEFAULT 'general'
+        COMMENT 'Grouping for admin UI / pricing matrix (links, domains, redirects, analytics, api, qr, linkspage, org, support)',
+
+    `isMeterable`           TINYINT(1) UNSIGNED NOT NULL DEFAULT 0
+        COMMENT 'Whether this feature may serve as a PAYG metering dimension (tblPricePlans.meteredFeatureUID / tblUsageCounters)',
+
+    `legacyColumn`          VARCHAR(50)         DEFAULT NULL
+        COMMENT 'The hard-coded tblSubscriptionTiers column this row replaces (maxLinks, hasAnalytics, …); drives the seed-018 backfill and legacy-shape output; NULL for new granular features',
+
+    `sortOrder`             INT UNSIGNED        NOT NULL DEFAULT 0
+        COMMENT 'Display order within category on pricing matrix / admin UI',
+
+    `isActive`              TINYINT(1) UNSIGNED NOT NULL DEFAULT 1
+        COMMENT 'Whether this feature participates in resolution (0 = parked; resolver ignores it entirely)',
+
+    `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`             DATETIME            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (`featureUID`),
+    UNIQUE KEY `UQ_feature_slug` (`featureSlug`),
+    UNIQUE KEY `UQ_feature_legacy_column` (`legacyColumn`),
+    INDEX `IDX_feature_category` (`category`, `sortOrder`),
+    INDEX `IDX_feature_active` (`isActive`),
+    INDEX `IDX_feature_meterable` (`isMeterable`, `isActive`)
+
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Feature registry — every gateable capability is one row; adding a feature never needs a schema change';
+
+-- =============================================================================
+-- 2. tblPricePlans — THE FLEXIBLE PRICE BOOK
+-- =============================================================================
+-- Flexibility requirements satisfied here:
+--   * "a tier can have MANY simultaneous price plans" — plans are rows keyed
+--     by tierID (nullable for tier-less add-ons / credit packs), so one tier
+--     can carry monthly GBP + annual GBP + intro EUR + lifetime + PAYG-capped
+--     rows all at once.
+--   * planType covers: 'recurring' (month/year via billingInterval ×
+--     intervalCount — quarterly = month×3), 'lifetime' (pay once, keep tier;
+--     tblSubscriptions.billingCycle ENUM already includes lifetime),
+--     'one_off' (single purchase, e.g. a setup fee or paid migration),
+--     'payg' (pure metered), 'payg_capped' (metered with a monthly cap equal
+--     to a flat tier price — see cap columns), plus two additive extensions:
+--     'addon' (recurring bolt-on that grants org feature overrides while
+--     active) and 'credit_pack' (one-off purchase of metered units →
+--     tblUsageCredits).
+--   * PAYG: meteredFeatureUID + unitPrice/unitSize + includedUnits define
+--     "£unitPrice per unitSize units of <feature> beyond includedUnits".
+--   * THE "PAYG CAPPED AT AN EQUIVALENT FLAT TIER PRICE" CASE:
+--     capAmount is the hard monthly spend ceiling; when capAmount is NULL and
+--     equivalentPlanUID is set, the cap IS that flat plan's current amount —
+--     so "PAYG, never more than Pro monthly" stays true automatically when
+--     the Pro price changes. capBehaviour states what happens at the cap:
+--       'flat_convert' — org is billed the cap and treated as entitled to the
+--                        equivalent plan's tier for the remainder of the period
+--       'hard_stop'    — metered feature blocks at the cap (fail closed on a
+--                        GENUINE limit, per the entitlements contract)
+--       'notify_only'  — keep metering, alert the owner (soft cap)
+--   * Limited-time / intro pricing: validFrom/validUntil bound offer windows;
+--     an expired plan stops being OFFERED but existing subscriptions keep it
+--     (grandfathering via tblSubscriptionPlans pinning).
+--   * Currency/region variants: (currency, region) rows per tier; region NULL
+--     = all regions. isDefault marks the advertised plan per currency/region.
+--   * Per-seat vs per-org: perSeatAmount (+ min/maxSeats) prices per user;
+--     NULL perSeatAmount = flat per-org amount. Both can combine (base + seats).
+--   * Scarcity (founding-member lifetime deals): maxSubscriptions caps total
+--     take-up; currentSubscriptions is maintained by the purchase flow.
+--   * DISABLED BY DEFAULT: isActive defaults to 0 — a newly inserted plan is
+--     inert until an operator activates it, matching the launch posture.
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS `tblPricePlans` (
+    `planUID`               BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT
+        COMMENT 'Unique row identifier',
+
+    `planSlug`              VARCHAR(100)        NOT NULL
+        COMMENT 'Stable identifier (e.g. pro-monthly-gbp, pro-lifetime-founder, payg-capped-pro-gbp)',
+
+    `planName`              VARCHAR(150)        NOT NULL
+        COMMENT 'Display name (e.g. "Pro — Monthly", "Founding Member Lifetime")',
+
+    `planDescription`       TEXT                DEFAULT NULL
+        COMMENT 'Marketing/admin description of this price plan',
+
+    `tierID`                VARCHAR(50)         DEFAULT NULL
+        COMMENT 'FK to tblSubscriptionTiers.tierID — the tier this plan sells. NULL for tier-less plans (addon, credit_pack, one_off)',
+
+    `planType`              ENUM('recurring', 'lifetime', 'one_off', 'payg', 'payg_capped', 'addon', 'credit_pack')
+                            NOT NULL DEFAULT 'recurring'
+        COMMENT 'Price structure (see table header for full semantics)',
+
+    `billingInterval`       ENUM('month', 'year')
+                            DEFAULT NULL
+        COMMENT 'Recurring interval unit; NULL for lifetime/one_off/credit_pack. PAYG plans bill monthly in arrears → month',
+
+    `intervalCount`         TINYINT UNSIGNED    NOT NULL DEFAULT 1
+        COMMENT 'Multiplier on billingInterval (quarterly = month × 3); ignored when billingInterval is NULL',
+
+    `amount`                DECIMAL(10, 2)      NOT NULL DEFAULT 0.00
+        COMMENT 'Flat price per interval (or once, for lifetime/one_off/credit_pack) in `currency`. 0.00 for pure PAYG (spend comes from usage)',
+
+    `currency`              CHAR(3)             NOT NULL DEFAULT 'GBP'
+        COMMENT 'ISO 4217 currency code — one plan row per currency variant',
+
+    `region`                VARCHAR(10)         DEFAULT NULL
+        COMMENT 'Region code this plan is offered in (GB, EU, US, ROW…); NULL = all regions. Enables regional price books',
+
+    `perSeatAmount`         DECIMAL(10, 2)      DEFAULT NULL
+        COMMENT 'Per-seat price per interval. NULL = per-org flat pricing (amount only); set = amount + (seats × perSeatAmount)',
+
+    `minSeats`              SMALLINT UNSIGNED   DEFAULT NULL
+        COMMENT 'Minimum billable seats when perSeatAmount is set (NULL = 1)',
+
+    `maxSeats`              SMALLINT UNSIGNED   DEFAULT NULL
+        COMMENT 'Maximum purchasable seats on this plan (NULL = no cap)',
+
+    `trialDays`             SMALLINT UNSIGNED   NOT NULL DEFAULT 0
+        COMMENT 'Free-trial length in days (feeds tblSubscriptions.trialEndsAt); 0 = no trial',
+
+    `meteredFeatureUID`     BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'FK to tblFeatures.featureUID — the metering dimension for payg/payg_capped/credit_pack (must have isMeterable=1; enforced in PHP, not a CHECK, for MySQL-version safety)',
+
+    `unitPrice`             DECIMAL(12, 6)      DEFAULT NULL
+        COMMENT 'PAYG price per unitSize units of the metered feature (6dp for sub-penny unit rates, e.g. £0.000100 per API request)',
+
+    `unitSize`              INT UNSIGNED        DEFAULT NULL
+        COMMENT 'Units per unitPrice (e.g. 1000 → price per 1,000 tracked clicks). NULL when not metered',
+
+    `includedUnits`         BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'Free allowance per period before PAYG metering starts (NULL = none)',
+
+    `capAmount`             DECIMAL(10, 2)      DEFAULT NULL
+        COMMENT 'payg_capped: maximum metered spend per period. NULL + equivalentPlanUID set = cap equals that plan''s CURRENT amount (auto-tracks flat-price changes)',
+
+    `equivalentPlanUID`     BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'Self-FK to the flat tblPricePlans row this PAYG cap is pegged to ("PAYG, never more than Pro monthly"); also names the tier entitlement granted on flat_convert',
+
+    `capBehaviour`          ENUM('flat_convert', 'hard_stop', 'notify_only')
+                            DEFAULT NULL
+        COMMENT 'What happens when the cap is reached (payg_capped only — see table header)',
+
+    `creditUnits`           BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'credit_pack only: metered units granted per purchase (lands in tblUsageCredits)',
+
+    `validFrom`             DATETIME            DEFAULT NULL
+        COMMENT 'Offer window start (limited-time / intro pricing); NULL = always offerable while isActive',
+
+    `validUntil`            DATETIME            DEFAULT NULL
+        COMMENT 'Offer window end — after this the plan cannot be NEWLY subscribed; existing subscriptions are grandfathered via tblSubscriptionPlans',
+
+    `maxSubscriptions`      INT UNSIGNED        DEFAULT NULL
+        COMMENT 'Scarcity cap on total take-up (e.g. 500 founding lifetime deals); NULL = uncapped',
+
+    `currentSubscriptions`  INT UNSIGNED        NOT NULL DEFAULT 0
+        COMMENT 'Running take-up count, maintained by the purchase flow (mirrors tblPaymentDiscounts.currentUses idiom)',
+
+    `isDefault`             TINYINT(1) UNSIGNED NOT NULL DEFAULT 0
+        COMMENT 'The advertised plan for its (tierID, currency, region, billingInterval) group on the pricing page',
+
+    `isVisible`             TINYINT(1) UNSIGNED NOT NULL DEFAULT 1
+        COMMENT 'Publicly listed (1) vs hidden/deal-only/grandfather-only (0) — hidden plans are still subscribable via direct link/admin',
+
+    `isActive`              TINYINT(1) UNSIGNED NOT NULL DEFAULT 0
+        COMMENT 'DISABLED BY DEFAULT (0): a plan must be explicitly activated by an operator before it can be offered — safe-launch posture',
+
+    `sortOrder`             INT UNSIGNED        NOT NULL DEFAULT 0
+        COMMENT 'Display order on the pricing page',
+
+    `metadataJSON`          JSON                DEFAULT NULL
+        COMMENT 'Provider mapping and future extension data (e.g. {"provider":"stripe","priceId":"price_..."}) — no schema change for provider IDs',
+
+    `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`             DATETIME            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (`planUID`),
+    UNIQUE KEY `UQ_priceplan_slug` (`planSlug`),
+    INDEX `IDX_priceplan_tier` (`tierID`, `isActive`, `isDefault`),
+    INDEX `IDX_priceplan_type` (`planType`, `isActive`),
+    INDEX `IDX_priceplan_currency_region` (`currency`, `region`, `isActive`),
+    INDEX `IDX_priceplan_window` (`validFrom`, `validUntil`),
+
+    CONSTRAINT `FK_priceplan_tier`
+        FOREIGN KEY (`tierID`)
+        REFERENCES `tblSubscriptionTiers` (`tierID`)
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT,
+
+    CONSTRAINT `FK_priceplan_metered_feature`
+        FOREIGN KEY (`meteredFeatureUID`)
+        REFERENCES `tblFeatures` (`featureUID`)
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT,
+
+    CONSTRAINT `FK_priceplan_equivalent_plan`
+        FOREIGN KEY (`equivalentPlanUID`)
+        REFERENCES `tblPricePlans` (`planUID`)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL
+
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Price book — any number of simultaneous price plans per tier: recurring, lifetime, one-off, PAYG, PAYG-capped, add-ons, credit packs, per currency/region/offer-window';
+
+-- =============================================================================
+-- 3. tblTierFeatures — TIER ↔ FEATURE ENTITLEMENTS
+-- =============================================================================
+-- Flexibility requirement satisfied: "any feature can be granted to any tier
+-- at any granularity" — the tier/feature matrix is DATA. A tier's entitlement
+-- for a feature is one row carrying a TYPED value:
+--
+--   valueBoolean — for valueType=boolean features
+--   valueInt     — for limit/quota features (the numeric cap/allowance)
+--   valueString  — for enum features
+--   valueJSON    — for config features AND any complex/experimental value a
+--                  simple column cannot express (the "normalised value + JSON
+--                  for complex" requirement — resolver prefers the typed
+--                  column, falls back to JSON)
+--   isUnlimited  — EXPLICIT unlimited marker (1 → limit/quota is ∞). Kept
+--                  separate from NULL so "unset" can never mean "unlimited"
+--                  (the legacy schema overloads NULL=unlimited; the resolver
+--                  maps isUnlimited=1 back to NULL in its legacy-shaped output)
+--
+-- EFFECTIVE-DATING (entitlement effective-dating requirement): a (tier,
+-- feature) pair may hold MULTIPLE rows with different effectiveFrom values —
+-- e.g. schedule "Pro gets 10 domains from 1 September" today. The resolver
+-- picks the row with the latest effectiveFrom <= NOW() whose effectiveUntil
+-- is NULL or > NOW(). The UNIQUE key includes a NULL-collapsed mirror of
+-- effectiveFrom (same #150 idiom as tblSettings.settingScopeRefKey, using the
+-- sentinel '1000-01-01' — a VALID date under NO_ZERO_DATE sql_mode) so two
+-- undated rows for the same pair are impossible.
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS `tblTierFeatures` (
+    `tierFeatureUID`        BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT
+        COMMENT 'Unique row identifier',
+
+    `tierID`                VARCHAR(50)         NOT NULL
+        COMMENT 'FK to tblSubscriptionTiers.tierID (same key tblSubscriptions/tblOrganisations use)',
+
+    `featureUID`            BIGINT UNSIGNED     NOT NULL
+        COMMENT 'FK to tblFeatures.featureUID',
+
+    `valueBoolean`          TINYINT(1) UNSIGNED DEFAULT NULL
+        COMMENT 'Typed value for boolean features (NULL = not this type)',
+
+    `valueInt`              BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'Typed value for limit/quota features (NULL = not this type OR unlimited — see isUnlimited)',
+
+    `valueString`           VARCHAR(255)        DEFAULT NULL
+        COMMENT 'Typed value for enum features (must be one of tblFeatures.allowedValues; enforced in PHP)',
+
+    `valueJSON`             JSON                DEFAULT NULL
+        COMMENT 'Value for config features / complex values beyond the typed columns',
+
+    `isUnlimited`           TINYINT(1) UNSIGNED NOT NULL DEFAULT 0
+        COMMENT 'Explicit unlimited marker for limit/quota features (1 = ∞; resolver outputs legacy NULL)',
+
+    `effectiveFrom`         DATETIME            DEFAULT NULL
+        COMMENT 'When this entitlement value starts applying (NULL = since forever) — enables scheduled tier changes',
+
+    `effectiveUntil`        DATETIME            DEFAULT NULL
+        COMMENT 'When this entitlement value stops applying (NULL = open-ended)',
+
+    -- NULL-collapsing mirror of effectiveFrom for the UNIQUE key (#150 idiom
+    -- from tblSettings): MySQL treats NULLs as distinct inside UNIQUE indexes,
+    -- so without this two undated rows for the same (tier, feature) pair would
+    -- both insert. '1000-01-01' is a legal DATETIME under the project's
+    -- NO_ZERO_DATE sql_mode (000_create_database.sql) — NOT a zero-date.
+    `effectiveFromKey`      DATETIME
+                            GENERATED ALWAYS AS (COALESCE(`effectiveFrom`, '1000-01-01 00:00:00')) STORED
+        COMMENT 'NULL-collapsed mirror of effectiveFrom so undated rows dedupe in UQ_tierfeature (settings #150 idiom)',
+
+    `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`             DATETIME            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (`tierFeatureUID`),
+    UNIQUE KEY `UQ_tierfeature` (`tierID`, `featureUID`, `effectiveFromKey`),
+    INDEX `IDX_tierfeature_feature` (`featureUID`),
+    INDEX `IDX_tierfeature_window` (`effectiveFrom`, `effectiveUntil`),
+
+    CONSTRAINT `FK_tierfeature_tier`
+        FOREIGN KEY (`tierID`)
+        REFERENCES `tblSubscriptionTiers` (`tierID`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+
+    CONSTRAINT `FK_tierfeature_feature`
+        FOREIGN KEY (`featureUID`)
+        REFERENCES `tblFeatures` (`featureUID`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Tier↔feature entitlement matrix as data — any feature grantable to any tier at any granularity, with effective-dating';
+
+-- =============================================================================
+-- 4. tblOrgFeatureOverrides — PER-ORG OVERRIDES / ADD-ONS / CUSTOM DEALS
+-- =============================================================================
+-- Flexibility requirement satisfied: "grant/deny/adjust a single feature for a
+-- single org beyond its tier". This is the add-on / comp / custom-deal /
+-- support-goodwill layer, applied ON TOP of the tier's entitlements by the
+-- resolver (merge order: feature default → tier value → org override).
+--
+-- overrideMode semantics:
+--   'grant'  — force a boolean feature ON for this org
+--   'deny'   — force a feature OFF (e.g. abuse response: pull custom-HTML from
+--              one org without touching its tier)
+--   'set'    — replace the tier value outright (typed columns / isUnlimited),
+--              e.g. a custom deal: maxLinks = 100,000 on Pro
+--   'adjust' — ADD adjustDelta to the tier's numeric value (stackable
+--              add-ons: "+5 domains" purchased twice = +10). Negative deltas
+--              reduce. Resolver floors the result at 0
+--
+-- Effective-dating gives free trials of single features, seasonal comps, and
+-- automatic expiry of purchased add-ons (billing renews by extending
+-- effectiveUntil). sourceType+sourcePlanUID record WHY the override exists —
+-- 'addon' rows point at the tblPricePlans addon plan that sold it.
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS `tblOrgFeatureOverrides` (
+    `overrideUID`           BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT
+        COMMENT 'Unique row identifier',
+
+    `orgHandle`             VARCHAR(50)         NOT NULL
+        COMMENT 'FK to tblOrganisations.orgHandle — the single org this override applies to',
+
+    `featureUID`            BIGINT UNSIGNED     NOT NULL
+        COMMENT 'FK to tblFeatures.featureUID — the single feature being overridden',
+
+    `overrideMode`          ENUM('grant', 'deny', 'set', 'adjust')
+                            NOT NULL DEFAULT 'set'
+        COMMENT 'How this override combines with the tier value (see table header)',
+
+    `valueBoolean`          TINYINT(1) UNSIGNED DEFAULT NULL
+        COMMENT 'set-mode replacement value for boolean features',
+
+    `valueInt`              BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'set-mode replacement value for limit/quota features',
+
+    `valueString`           VARCHAR(255)        DEFAULT NULL
+        COMMENT 'set-mode replacement value for enum features',
+
+    `valueJSON`             JSON                DEFAULT NULL
+        COMMENT 'set-mode replacement value for config features / complex values',
+
+    `isUnlimited`           TINYINT(1) UNSIGNED NOT NULL DEFAULT 0
+        COMMENT 'set-mode: explicit unlimited (1 = ∞ for this org, this feature)',
+
+    `adjustDelta`           BIGINT              DEFAULT NULL
+        COMMENT 'adjust-mode: SIGNED delta applied to the tier''s numeric value (+5 domains, -100 links); NULL for other modes',
+
+    `effectiveFrom`         DATETIME            DEFAULT NULL
+        COMMENT 'When the override starts (NULL = immediately)',
+
+    `effectiveUntil`        DATETIME            DEFAULT NULL
+        COMMENT 'When the override lapses (NULL = until removed) — add-on renewals extend this',
+
+    `sourceType`            ENUM('addon', 'comp', 'custom_deal', 'trial', 'support', 'migration')
+                            NOT NULL DEFAULT 'custom_deal'
+        COMMENT 'Why this override exists (audit/reporting): purchased add-on, goodwill comp, negotiated deal, feature trial, support action, data migration',
+
+    `sourcePlanUID`         BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'FK to tblPricePlans.planUID when sourceType=addon/credit purchase — links the override to the plan that sold it',
+
+    `notes`                 TEXT                DEFAULT NULL
+        COMMENT 'Free-text audit note (who agreed what, ticket ref, etc.)',
+
+    `createdByUserUID`      BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'FK to tblUsers.userUID — the admin who created this override (NULL = system)',
+
+    `isActive`              TINYINT(1) UNSIGNED NOT NULL DEFAULT 1
+        COMMENT 'Soft on/off without losing the audit row',
+
+    `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`             DATETIME            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (`overrideUID`),
+    INDEX `IDX_orgoverride_org_feature` (`orgHandle`, `featureUID`, `isActive`),
+    INDEX `IDX_orgoverride_feature` (`featureUID`),
+    INDEX `IDX_orgoverride_window` (`effectiveFrom`, `effectiveUntil`),
+
+    CONSTRAINT `FK_orgoverride_org`
+        FOREIGN KEY (`orgHandle`)
+        REFERENCES `tblOrganisations` (`orgHandle`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+
+    CONSTRAINT `FK_orgoverride_feature`
+        FOREIGN KEY (`featureUID`)
+        REFERENCES `tblFeatures` (`featureUID`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+
+    CONSTRAINT `FK_orgoverride_source_plan`
+        FOREIGN KEY (`sourcePlanUID`)
+        REFERENCES `tblPricePlans` (`planUID`)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL,
+
+    CONSTRAINT `FK_orgoverride_created_by`
+        FOREIGN KEY (`createdByUserUID`)
+        REFERENCES `tblUsers` (`userUID`)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL
+
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Per-org feature overrides — add-ons, comps, custom deals, feature trials — applied on top of tier entitlements, with effective-dating and audit trail';
+
+-- =============================================================================
+-- 5. tblCoupons — DISCOUNT/COUPON ENGINE (supersedes 2-type tblPaymentDiscounts)
+-- =============================================================================
+-- Flexibility requirement satisfied: "extend beyond the current 2 ENUM types to
+-- cover intro, limited-time, lifetime, first-N-periods, stacking rules,
+-- per-plan applicability" — WITHOUT altering tblPaymentDiscounts (additive
+-- rule). tblPaymentDiscounts stays for historical rows and the legacy path;
+-- legacyDiscountUID links a migrated coupon back to its old row.
+--
+--   discountKind:  'percentage' | 'fixed_amount' (the two legacy kinds)
+--                  + 'free_periods'   (N periods at £0 — classic intro offer)
+--                  + 'override_price' (charge exactly discountValue instead of
+--                                      the plan price — clean intro pricing
+--                                      without percentage rounding artefacts)
+--   durationType:  'once'            (first payment only)
+--                  'first_n_periods' (durationPeriods payments)
+--                  'forever'         (every payment, i.e. a LIFETIME discount)
+--                  'until_date'      (every payment until durationUntil)
+--   Applicability: any combination of applicablePlanUID (one plan),
+--                  applicableTierID (any plan of a tier), applicablePlanType
+--                  (e.g. recurring only — keeps coupons off lifetime deals).
+--                  All NULL = applies to everything.
+--   Stacking:      isStackable=0 → never combines with another coupon.
+--                  isStackable=1 → combines ONLY with coupons whose
+--                  stackingGroup differs (same group = mutually exclusive,
+--                  e.g. two 'sector' discounts can never stack). The master
+--                  switch billing.coupon_stacking_enabled (seeded OFF) disables
+--                  all stacking regardless.
+--   Windows/caps:  validFrom/validUntil (limited-time), maxUses (global),
+--                  perOrgMaxUses (per-customer), enforced via
+--                  tblCouponRedemptions.
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS `tblCoupons` (
+    `couponUID`             BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT
+        COMMENT 'Unique row identifier',
+
+    `couponCode`            VARCHAR(50)         DEFAULT NULL
+        COMMENT 'Redeemable code (NULL = automatic discount applied by rule, mirroring tblPaymentDiscounts.discountCode)',
+
+    `couponName`            VARCHAR(255)        NOT NULL
+        COMMENT 'Display name (e.g. "Launch offer — 25% off 3 months")',
+
+    `discountKind`          ENUM('percentage', 'fixed_amount', 'free_periods', 'override_price')
+                            NOT NULL DEFAULT 'percentage'
+        COMMENT 'Discount mechanics (see table header)',
+
+    `discountValue`         DECIMAL(10, 2)      NOT NULL DEFAULT 0.00
+        COMMENT 'Percentage (0–100), fixed amount off, or override price; ignored for free_periods',
+
+    `durationType`          ENUM('once', 'first_n_periods', 'forever', 'until_date')
+                            NOT NULL DEFAULT 'once'
+        COMMENT 'How long the discount keeps applying to a subscription (forever = lifetime discount)',
+
+    `durationPeriods`       SMALLINT UNSIGNED   DEFAULT NULL
+        COMMENT 'first_n_periods: number of billing periods discounted (also the N for free_periods)',
+
+    `durationUntil`         DATETIME            DEFAULT NULL
+        COMMENT 'until_date: last date the discount applies to renewals',
+
+    `applicablePlanUID`     BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'Restrict to one price plan (NULL = no plan restriction)',
+
+    `applicableTierID`      VARCHAR(50)         DEFAULT NULL
+        COMMENT 'Restrict to any plan of one tier (NULL = no tier restriction; replaces tblPaymentDiscounts.applicableTier as a real FK)',
+
+    `applicablePlanType`    ENUM('recurring', 'lifetime', 'one_off', 'payg', 'payg_capped', 'addon', 'credit_pack')
+                            DEFAULT NULL
+        COMMENT 'Restrict to a plan type (e.g. recurring only, keeping coupons off lifetime deals); NULL = any',
+
+    `minAmount`             DECIMAL(10, 2)      DEFAULT NULL
+        COMMENT 'Minimum pre-discount charge for the coupon to apply (NULL = none)',
+
+    `maxUses`               INT UNSIGNED        DEFAULT NULL
+        COMMENT 'Global redemption cap (NULL = unlimited)',
+
+    `currentUses`           INT UNSIGNED        NOT NULL DEFAULT 0
+        COMMENT 'Running redemption count (kept in step with tblCouponRedemptions by the redemption flow)',
+
+    `perOrgMaxUses`         SMALLINT UNSIGNED   DEFAULT NULL
+        COMMENT 'Per-organisation redemption cap (NULL = unlimited; typical value 1)',
+
+    `isStackable`           TINYINT(1) UNSIGNED NOT NULL DEFAULT 0
+        COMMENT 'Whether this coupon may combine with others (subject to stackingGroup + master switch)',
+
+    `stackingGroup`         VARCHAR(50)         DEFAULT NULL
+        COMMENT 'Coupons sharing a group are mutually exclusive even when stackable (e.g. all sector discounts in group "sector")',
+
+    `legacyDiscountUID`     BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'FK to tblPaymentDiscounts.discountUID when this coupon was migrated from the legacy table (audit/continuity)',
+
+    `validFrom`             DATETIME            DEFAULT NULL
+        COMMENT 'Redemption window start (limited-time offers)',
+
+    `validUntil`            DATETIME            DEFAULT NULL
+        COMMENT 'Redemption window end',
+
+    `isActive`              TINYINT(1) UNSIGNED NOT NULL DEFAULT 0
+        COMMENT 'DISABLED BY DEFAULT (0) — a coupon must be explicitly activated, matching the plan posture',
+
+    `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`             DATETIME            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (`couponUID`),
+    UNIQUE KEY `UQ_coupon_code` (`couponCode`),
+    INDEX `IDX_coupon_active_window` (`isActive`, `validFrom`, `validUntil`),
+    INDEX `IDX_coupon_plan` (`applicablePlanUID`),
+    INDEX `IDX_coupon_tier` (`applicableTierID`),
+
+    CONSTRAINT `FK_coupon_plan`
+        FOREIGN KEY (`applicablePlanUID`)
+        REFERENCES `tblPricePlans` (`planUID`)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL,
+
+    CONSTRAINT `FK_coupon_tier`
+        FOREIGN KEY (`applicableTierID`)
+        REFERENCES `tblSubscriptionTiers` (`tierID`)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL,
+
+    CONSTRAINT `FK_coupon_legacy_discount`
+        FOREIGN KEY (`legacyDiscountUID`)
+        REFERENCES `tblPaymentDiscounts` (`discountUID`)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL
+
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Coupon/discount engine — intro, limited-time, lifetime, first-N-periods, price-override and free-period discounts with stacking rules and per-plan/tier/type applicability';
+
+-- =============================================================================
+-- 6. tblCouponRedemptions — WHO USED WHICH COUPON (enforces caps)
+-- =============================================================================
+-- Enforcement backing for tblCoupons.maxUses / perOrgMaxUses, and the audit
+-- trail tying a discount to the subscription/payment it touched (tblPayments
+-- keeps its own discountAmount column untouched — compatibility rule).
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS `tblCouponRedemptions` (
+    `redemptionUID`         BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT
+        COMMENT 'Unique row identifier',
+
+    `couponUID`             BIGINT UNSIGNED     NOT NULL
+        COMMENT 'FK to tblCoupons.couponUID',
+
+    `orgHandle`             VARCHAR(50)         NOT NULL
+        COMMENT 'FK to tblOrganisations.orgHandle — the redeeming org',
+
+    `subscriptionUID`       BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'FK to tblSubscriptions.subscriptionUID the coupon is attached to (NULL for one-off purchases)',
+
+    `paymentUID`            BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'FK to tblPayments.paymentUID of the first discounted payment (NULL until first charge)',
+
+    `amountDiscounted`      DECIMAL(10, 2)      NOT NULL DEFAULT 0.00
+        COMMENT 'Total discounted so far under this redemption (updated on each discounted renewal)',
+
+    `periodsApplied`        SMALLINT UNSIGNED   NOT NULL DEFAULT 0
+        COMMENT 'How many billing periods have received this discount (drives first_n_periods expiry)',
+
+    `redeemedAt`            DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP
+        COMMENT 'When the coupon was redeemed',
+
+    `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`             DATETIME            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (`redemptionUID`),
+    INDEX `IDX_redemption_coupon_org` (`couponUID`, `orgHandle`),
+    INDEX `IDX_redemption_org` (`orgHandle`),
+    INDEX `IDX_redemption_subscription` (`subscriptionUID`),
+
+    CONSTRAINT `FK_redemption_coupon`
+        FOREIGN KEY (`couponUID`)
+        REFERENCES `tblCoupons` (`couponUID`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+
+    CONSTRAINT `FK_redemption_org`
+        FOREIGN KEY (`orgHandle`)
+        REFERENCES `tblOrganisations` (`orgHandle`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+
+    CONSTRAINT `FK_redemption_subscription`
+        FOREIGN KEY (`subscriptionUID`)
+        REFERENCES `tblSubscriptions` (`subscriptionUID`)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL,
+
+    CONSTRAINT `FK_redemption_payment`
+        FOREIGN KEY (`paymentUID`)
+        REFERENCES `tblPayments` (`paymentUID`)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL
+
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Coupon redemption ledger — enforces global/per-org usage caps and first-N-periods duration, and audits discount attribution';
+
+-- =============================================================================
+-- 7. tblSubscriptionPlans — SUBSCRIPTION ↔ PRICE-PLAN PIN (GRANDFATHERING)
+-- =============================================================================
+-- Compatibility requirement satisfied: "Keep tblSubscriptions/tblPayments
+-- compatible" — instead of ALTERing tblSubscriptions to add a planUID column,
+-- this bridge table attaches plan context to an existing subscription row.
+-- tblSubscriptions keeps carrying tierID/billingCycle/status/periods exactly
+-- as today (legacy code keeps working); the pricing engine additionally knows
+-- WHICH plan, at WHAT pinned price.
+--
+-- GRANDFATHERING: priceAtSubscription / capAmountAtSubscription freeze the
+-- deal at purchase time. Repricing a plan or retiring it (isActive=0 /
+-- validUntil passed) never changes what an existing subscriber pays — their
+-- pinned row rules until THEY change plan (which writes a new row and closes
+-- the old one via isCurrent/effectiveUntil, preserving full plan history).
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS `tblSubscriptionPlans` (
+    `subscriptionPlanUID`   BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT
+        COMMENT 'Unique row identifier',
+
+    `subscriptionUID`       BIGINT UNSIGNED     NOT NULL
+        COMMENT 'FK to tblSubscriptions.subscriptionUID — the legacy subscription row this plan context attaches to',
+
+    `planUID`               BIGINT UNSIGNED     NOT NULL
+        COMMENT 'FK to tblPricePlans.planUID — the exact plan subscribed',
+
+    `priceAtSubscription`   DECIMAL(10, 2)      NOT NULL
+        COMMENT 'GRANDFATHER PIN: the per-interval amount agreed at purchase — future plan repricing never touches this subscriber',
+
+    `currencyAtSubscription` CHAR(3)            NOT NULL DEFAULT 'GBP'
+        COMMENT 'Currency of the pinned price (ISO 4217)',
+
+    `seats`                 SMALLINT UNSIGNED   DEFAULT NULL
+        COMMENT 'Purchased seat count for per-seat plans (NULL = per-org plan)',
+
+    `perSeatPriceAtSubscription` DECIMAL(10, 2) DEFAULT NULL
+        COMMENT 'GRANDFATHER PIN for the per-seat component (NULL = plan had none)',
+
+    `capAmountAtSubscription` DECIMAL(10, 2)    DEFAULT NULL
+        COMMENT 'GRANDFATHER PIN for a payg_capped cap — "never more than Pro at the price Pro was when I signed up"',
+
+    `isCurrent`             TINYINT(1) UNSIGNED NOT NULL DEFAULT 1
+        COMMENT '1 = the active plan row for this subscription; plan changes close the old row (0) and insert a new one — full history retained',
+
+    `effectiveFrom`         DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP
+        COMMENT 'When this plan attachment began',
+
+    `effectiveUntil`        DATETIME            DEFAULT NULL
+        COMMENT 'When it ended (NULL while current)',
+
+    `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`             DATETIME            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (`subscriptionPlanUID`),
+    INDEX `IDX_subplan_subscription` (`subscriptionUID`, `isCurrent`),
+    INDEX `IDX_subplan_plan` (`planUID`),
+
+    CONSTRAINT `FK_subplan_subscription`
+        FOREIGN KEY (`subscriptionUID`)
+        REFERENCES `tblSubscriptions` (`subscriptionUID`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+
+    CONSTRAINT `FK_subplan_plan`
+        FOREIGN KEY (`planUID`)
+        REFERENCES `tblPricePlans` (`planUID`)
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT
+
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Attaches price-plan context (with grandfather price pins and plan history) to unmodified tblSubscriptions rows';
+
+-- =============================================================================
+-- 8. tblUsageCounters — AGGREGATED USAGE METERING (PAYG + caps + quotas)
+-- =============================================================================
+-- Flexibility requirement satisfied: "Usage metering to support PAYG + caps."
+-- One row per (org, meterable feature, period) holding an aggregate count —
+-- cheap to read on every gate check, cheap to bump on every metered action
+-- (single UPSERT), suitable for Dreamhost shared hosting (no cron assumed;
+-- period rows are created lazily on first use, old rows pruned
+-- probabilistically like tblAPIRequestLog's 1-in-100 sweep).
+--
+-- periodType 'day' backs daily quotas (api.requests_per_day), 'month' backs
+-- calendar-month PAYG billing, 'billing_period' backs metering aligned to a
+-- subscription's own anniversary (periodStart = currentPeriodStart date).
+-- The PAYG invoice for a period = SUM over counters × plan unitPrice, minus
+-- includedUnits and credits, capped per plan capAmount/equivalentPlan.
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS `tblUsageCounters` (
+    `counterUID`            BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT
+        COMMENT 'Unique row identifier',
+
+    `orgHandle`             VARCHAR(50)         NOT NULL
+        COMMENT 'FK to tblOrganisations.orgHandle',
+
+    `featureUID`            BIGINT UNSIGNED     NOT NULL
+        COMMENT 'FK to tblFeatures.featureUID — must be an isMeterable feature (enforced in PHP)',
+
+    `periodType`            ENUM('day', 'month', 'billing_period')
+                            NOT NULL DEFAULT 'month'
+        COMMENT 'Aggregation window kind (see table header)',
+
+    `periodStart`           DATE                NOT NULL
+        COMMENT 'First day of the window (the day itself for day; month start for month; subscription anniversary for billing_period)',
+
+    `usedCount`             BIGINT UNSIGNED     NOT NULL DEFAULT 0
+        COMMENT 'Units consumed in this window (atomic UPSERT: INSERT … ON DUPLICATE KEY UPDATE usedCount = usedCount + n)',
+
+    `lastEventAt`           DATETIME            DEFAULT NULL
+        COMMENT 'Timestamp of the most recent metered event (staleness checks/debug)',
+
+    `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`             DATETIME            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (`counterUID`),
+    UNIQUE KEY `UQ_usage_counter` (`orgHandle`, `featureUID`, `periodType`, `periodStart`),
+    INDEX `IDX_usage_feature_period` (`featureUID`, `periodType`, `periodStart`),
+
+    CONSTRAINT `FK_usage_counter_org`
+        FOREIGN KEY (`orgHandle`)
+        REFERENCES `tblOrganisations` (`orgHandle`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+
+    CONSTRAINT `FK_usage_counter_feature`
+        FOREIGN KEY (`featureUID`)
+        REFERENCES `tblFeatures` (`featureUID`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Aggregated per-org usage counters per meterable feature and period — powers quotas, PAYG billing, and PAYG caps';
+
+-- =============================================================================
+-- 9. tblUsageCredits — PURCHASED/GRANTED UNIT CREDITS (credit packs)
+-- =============================================================================
+-- Backs the credit-pack mechanic (tblPricePlans.planType='credit_pack') and
+-- goodwill/referral unit grants: a bucket of prepaid units for one meterable
+-- feature, drawn down before PAYG charging kicks in. Oldest non-expired
+-- bucket is consumed first (FIFO in PHP).
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS `tblUsageCredits` (
+    `creditUID`             BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT
+        COMMENT 'Unique row identifier',
+
+    `orgHandle`             VARCHAR(50)         NOT NULL
+        COMMENT 'FK to tblOrganisations.orgHandle',
+
+    `featureUID`            BIGINT UNSIGNED     NOT NULL
+        COMMENT 'FK to tblFeatures.featureUID — the meterable feature these credits apply to',
+
+    `unitsGranted`          BIGINT UNSIGNED     NOT NULL
+        COMMENT 'Units in the bucket at purchase/grant time',
+
+    `unitsRemaining`        BIGINT UNSIGNED     NOT NULL
+        COMMENT 'Units left (decremented as usage draws down)',
+
+    `sourcePlanUID`         BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'FK to tblPricePlans.planUID of the credit_pack purchased (NULL for goodwill/referral grants)',
+
+    `sourcePaymentUID`      BIGINT UNSIGNED     DEFAULT NULL
+        COMMENT 'FK to tblPayments.paymentUID that bought this bucket (NULL for grants)',
+
+    `expiresAt`             DATETIME            DEFAULT NULL
+        COMMENT 'When unused credits lapse (NULL = never)',
+
+    `notes`                 VARCHAR(255)        DEFAULT NULL
+        COMMENT 'Audit note (e.g. "referral reward", ticket ref)',
+
+    `isActive`              TINYINT(1) UNSIGNED NOT NULL DEFAULT 1
+        COMMENT 'Soft disable without losing the audit row',
+
+    `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`             DATETIME            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (`creditUID`),
+    INDEX `IDX_credit_org_feature` (`orgHandle`, `featureUID`, `isActive`, `expiresAt`),
+
+    CONSTRAINT `FK_credit_org`
+        FOREIGN KEY (`orgHandle`)
+        REFERENCES `tblOrganisations` (`orgHandle`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+
+    CONSTRAINT `FK_credit_feature`
+        FOREIGN KEY (`featureUID`)
+        REFERENCES `tblFeatures` (`featureUID`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+
+    CONSTRAINT `FK_credit_source_plan`
+        FOREIGN KEY (`sourcePlanUID`)
+        REFERENCES `tblPricePlans` (`planUID`)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL,
+
+    CONSTRAINT `FK_credit_source_payment`
+        FOREIGN KEY (`sourcePaymentUID`)
+        REFERENCES `tblPayments` (`paymentUID`)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL
+
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Prepaid metered-unit buckets (credit packs, referral/goodwill grants) drawn down before PAYG charging';
+
+-- =============================================================================
+-- 10. tblUsageEvents — OPTIONAL FINE-GRAINED USAGE LEDGER (audit / disputes)
+-- =============================================================================
+-- The counters table is the OPERATIONAL source; this ledger is the AUDIT
+-- source for PAYG billing disputes ("show me the 4,213 API calls you billed").
+-- Writing here is gated by 'billing.usage_metering_enabled' AND is safe to
+-- disable independently — billing maths only reads counters. eventRef gives
+-- idempotent recording (retried requests carrying the same ref insert once:
+-- multiple NULLs are permitted in a UNIQUE index, real refs dedupe).
+-- Pruned probabilistically (1-in-100 request sweep, retention setting below),
+-- mirroring the tblAPIRequestLog pattern — no cron dependency on shared
+-- hosting.
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS `tblUsageEvents` (
+    `eventUID`              BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT
+        COMMENT 'Unique row identifier',
+
+    `orgHandle`             VARCHAR(50)         NOT NULL
+        COMMENT 'FK to tblOrganisations.orgHandle',
+
+    `featureUID`            BIGINT UNSIGNED     NOT NULL
+        COMMENT 'FK to tblFeatures.featureUID — the metered dimension',
+
+    `quantity`              INT UNSIGNED        NOT NULL DEFAULT 1
+        COMMENT 'Units consumed by this event (bulk API call may consume many)',
+
+    `eventRef`              VARCHAR(100)        DEFAULT NULL
+        COMMENT 'Caller-supplied idempotency reference (NULL allowed repeatedly; non-NULL values are unique per feature)',
+
+    `contextJSON`           JSON                DEFAULT NULL
+        COMMENT 'Optional event context for audit (endpoint, shortURL id, …) — never PII beyond what tblActivityLog already holds',
+
+    `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (`eventUID`),
+    UNIQUE KEY `UQ_usage_event_ref` (`featureUID`, `eventRef`),
+    INDEX `IDX_usage_event_org` (`orgHandle`, `featureUID`, `createdAt`),
+    INDEX `IDX_usage_event_created` (`createdAt`),
+
+    CONSTRAINT `FK_usage_event_org`
+        FOREIGN KEY (`orgHandle`)
+        REFERENCES `tblOrganisations` (`orgHandle`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+
+    CONSTRAINT `FK_usage_event_feature`
+        FOREIGN KEY (`featureUID`)
+        REFERENCES `tblFeatures` (`featureUID`)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Optional fine-grained usage event ledger for PAYG audit/disputes — counters remain the operational metering source';
+
+-- =============================================================================
+-- 11. VERIFICATION VIEW — legacy-shaped read of the NEW model
+-- =============================================================================
+-- vwSubscriptionTierEntitlements pivots tblTierFeatures back into the exact
+-- column shape of tblSubscriptionTiers' hard-coded columns. Purpose:
+--   (a) MIGRATION VERIFICATION: after the seed-018 backfill,
+--         SELECT ... FROM tblSubscriptionTiers t
+--         JOIN vwSubscriptionTierEntitlements v USING (tierID)
+--       must show identical values column-for-column (see
+--       tests/integration/pricing_backfill_verify.php);
+--   (b) TRANSITION AID: any legacy reporting query can point at the view.
+-- The view only reads CURRENTLY-EFFECTIVE undated-or-started rows; the PHP
+-- resolver (not this view) is the runtime authority.
+-- CREATE OR REPLACE is idempotent; a view is additive (no data, no triggers).
+-- =============================================================================
+CREATE OR REPLACE VIEW `vwSubscriptionTierEntitlements` AS
+SELECT
+    tf.`tierID` AS `tierID`,
+    MAX(CASE WHEN f.`featureSlug` = 'links.max'
+             THEN CASE WHEN tf.`isUnlimited` = 1 THEN NULL ELSE tf.`valueInt` END END) AS `maxLinks`,
+    MAX(CASE WHEN f.`featureSlug` = 'domains.custom_max'
+             THEN CASE WHEN tf.`isUnlimited` = 1 THEN NULL ELSE tf.`valueInt` END END) AS `maxCustomDomains`,
+    MAX(CASE WHEN f.`featureSlug` = 'api.requests_per_day'
+             THEN CASE WHEN tf.`isUnlimited` = 1 THEN NULL ELSE tf.`valueInt` END END) AS `maxAPIRequestsPerDay`,
+    MAX(CASE WHEN f.`featureSlug` = 'linkspage.pages_max'
+             THEN CASE WHEN tf.`isUnlimited` = 1 THEN NULL ELSE tf.`valueInt` END END) AS `maxLinksPages`,
+    MAX(CASE WHEN f.`featureSlug` = 'redirects.advanced'  THEN tf.`valueBoolean` END) AS `hasAdvancedRedirects`,
+    MAX(CASE WHEN f.`featureSlug` = 'analytics.enabled'   THEN tf.`valueBoolean` END) AS `hasAnalytics`,
+    MAX(CASE WHEN f.`featureSlug` = 'qr.dynamic'          THEN tf.`valueBoolean` END) AS `hasQRCodes`,
+    MAX(CASE WHEN f.`featureSlug` = 'api.access'          THEN tf.`valueBoolean` END) AS `hasAPIAccess`,
+    MAX(CASE WHEN f.`featureSlug` = 'support.priority'    THEN tf.`valueBoolean` END) AS `hasPrioritySupport`,
+    MAX(CASE WHEN f.`featureSlug` = 'linkspage.custom_html' THEN tf.`valueBoolean` END) AS `hasCustomHTML`
+FROM `tblTierFeatures` tf
+INNER JOIN `tblFeatures` f
+        ON f.`featureUID` = tf.`featureUID`
+       AND f.`isActive`   = 1
+WHERE (tf.`effectiveFrom`  IS NULL OR tf.`effectiveFrom`  <= NOW())
+  AND (tf.`effectiveUntil` IS NULL OR tf.`effectiveUntil` >  NOW())
+GROUP BY tf.`tierID`;
+
+-- End of file.

--- a/web/_sql/seeds/018_pricing_feature_registry.sql
+++ b/web/_sql/seeds/018_pricing_feature_registry.sql
@@ -1,0 +1,220 @@
+-- Copyright (c) 2024–2026 MWBM Partners Ltd (MWservices).
+-- All rights reserved.
+--
+-- This source code is proprietary and confidential.
+-- Unauthorised copying, modification, or distribution is strictly prohibited.
+
+-- =============================================================================
+-- Go2My.Link — Pricing Engine: Feature Registry Seed + Legacy Backfill
+-- =============================================================================
+-- MIGRATION PATH FROM THE FIXED COLUMNS (full plan in the pricing-engine
+-- scaffold build plan, kept alongside Pricing_Strategy.md):
+--
+--   STEP 1 (THIS FILE, automatic): seed tblFeatures — one row per legacy
+--     tblSubscriptionTiers column (legacyColumn set) plus the new granular
+--     features — then copy every tier's current column values into
+--     tblTierFeatures via idempotent INSERT…SELECTs. Legacy NULL (=unlimited)
+--     becomes isUnlimited=1. Booleans copy verbatim. After this file runs, the
+--     new model REPRODUCES the legacy model exactly; nothing reads it yet
+--     (billing.pricing_engine_enabled is still '0' — seeded by
+--     019_pricing_settings.sql).
+--
+--   STEP 2 (operator, later): flip billing.pricing_engine_enabled to '1'.
+--     entitlements.php now resolves through web/_functions/pricing.php (merge
+--     order: feature safe-floor default → tier value → org override). Because
+--     STEP 1 copied values verbatim, resolution output is IDENTICAL — flip is
+--     a no-op until tier/feature data is deliberately changed. Flip back to
+--     '0' at any time (instant rollback; legacy columns were never modified).
+--
+--   STEP 3 (cleanup, MUCH later, separate sign-off): once the engine has been
+--     ON and stable for a full release cycle, the legacy has*/max* columns can
+--     be retired — recommended END STATE is to KEEP the columns frozen (cheap,
+--     zero risk, still additive) or replace reads with
+--     vwSubscriptionTierEntitlements (schema 036); physically dropping columns
+--     would be a destructive change and is deliberately NOT part of this
+--     proposal.
+--
+-- This file requires web/_sql/schema/036_pricing_engine.sql (tblFeatures,
+-- tblTierFeatures) and web/_sql/seeds/001_subscription_tiers.sql (the tier
+-- rows being backfilled from) to have already run — both are earlier in
+-- filename sort order, so a fresh install picks this up automatically.
+--
+-- Every INSERT below is idempotent (unique keys + ON DUPLICATE KEY no-op),
+-- so re-running is safe and never overwrites an operator's later edits —
+-- the same content is reused verbatim by
+-- web/_sql/migrations/020_pricing_engine.sql for already-deployed databases.
+--
+-- @package    Go2My.Link
+-- @subpackage Seeds
+-- @version    1.0.0
+-- @since      v1.6.0 — Pricing Engine phase (scaffold)
+--
+-- 📖 References:
+--     - Tables:        web/_sql/schema/036_pricing_engine.sql
+--     - Engine switch:  web/_sql/seeds/019_pricing_settings.sql
+--     - Legacy tiers:   web/_sql/schema/011_core_subscription_tiers.sql
+--     - Tier seed:      web/_sql/seeds/001_subscription_tiers.sql
+-- =============================================================================
+
+USE `mwtools_Go2MyLink`;
+
+-- -----------------------------------------------------------------------------
+-- 1. Registry rows replacing the legacy hard-coded columns (legacyColumn set)
+-- -----------------------------------------------------------------------------
+INSERT INTO `tblFeatures` (
+    `featureSlug`, `featureName`, `featureDescription`,
+    `valueType`, `valueUnit`, `quotaPeriod`,
+    `defaultValueBoolean`, `defaultValueInt`, `defaultIsUnlimited`,
+    `category`, `isMeterable`, `legacyColumn`, `sortOrder`, `isActive`
+) VALUES
+('links.max', 'Active short links', 'Maximum simultaneously active short URLs for the organisation.',
+ 'limit', 'links', NULL, NULL, 0, 0, 'links', 1, 'maxLinks', 10, 1),
+('domains.custom_max', 'Custom short domains', 'Maximum ownership-verified custom short domains.',
+ 'limit', 'domains', NULL, NULL, 0, 0, 'domains', 0, 'maxCustomDomains', 10, 1),
+('api.requests_per_day', 'API requests per day', 'Daily API request allowance across the organisation''s keys.',
+ 'quota', 'requests', 'day', NULL, 0, 0, 'api', 1, 'maxAPIRequestsPerDay', 20, 1),
+('linkspage.pages_max', 'LinksPages', 'Maximum LinksPage (link-in-bio) pages.',
+ 'limit', 'pages', NULL, NULL, 0, 0, 'linkspage', 0, 'maxLinksPages', 10, 1),
+('redirects.advanced', 'Advanced redirects (umbrella)', 'Legacy umbrella flag for scheduled/device/geo/age-gate redirects. Superseded by the granular redirects.* flags; resolver reports it ON when ANY granular redirect flag is ON.',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'redirects', 0, 'hasAdvancedRedirects', 5, 1),
+('analytics.enabled', 'Analytics dashboard', 'Org-scoped click/human/bot/unique-IP analytics dashboard.',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'analytics', 0, 'hasAnalytics', 10, 1),
+('qr.dynamic', 'Dynamic QR codes', 'CueRCode dynamic-QR integration (re-pointable codes).',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'qr', 0, 'hasQRCodes', 10, 1),
+('api.access', 'API access', 'Public API v1 access (key auth, scopes).',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'api', 0, 'hasAPIAccess', 10, 1),
+('support.priority', 'Priority support', 'Priority support queue.',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'support', 0, 'hasPrioritySupport', 10, 1),
+('linkspage.custom_html', 'LinksPage custom HTML/CSS', 'High-risk premium feature: free-form custom HTML/CSS on LinksPages (Component C.6, #49). Also governed by the linkspage.custom_html_enabled kill-switch.',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'linkspage', 0, 'hasCustomHTML', 40, 1)
+ON DUPLICATE KEY UPDATE
+    `featureDescription` = VALUES(`featureDescription`);
+
+-- -----------------------------------------------------------------------------
+-- 2. NEW granular registry rows (no legacy column; enforcement arrives with
+--    the engine). Adding these here proves the core claim: features are rows,
+--    not schema.
+-- -----------------------------------------------------------------------------
+INSERT INTO `tblFeatures` (
+    `featureSlug`, `featureName`, `featureDescription`,
+    `valueType`, `valueUnit`, `quotaPeriod`,
+    `defaultValueBoolean`, `defaultValueInt`, `defaultIsUnlimited`,
+    `category`, `isMeterable`, `legacyColumn`, `sortOrder`, `isActive`
+) VALUES
+('links.custom_alias', 'Custom aliases', 'Choose custom short-link aliases.',
+ 'boolean', NULL, NULL, 1, NULL, 0, 'links', 0, NULL, 20, 1),
+('redirects.scheduled', 'Scheduled redirects', 'Time-window destination switching (schema 021).',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'redirects', 0, NULL, 10, 1),
+('redirects.device', 'Device-based redirects', 'Destination by device class (schema 021).',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'redirects', 0, NULL, 20, 1),
+('redirects.geo', 'Geo-based redirects', 'Destination by visitor country (schema 021).',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'redirects', 0, NULL, 30, 1),
+('redirects.agegate', 'Age-gate redirects', 'Age-verification interstitial before redirect (schema 021).',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'redirects', 0, NULL, 40, 1),
+('analytics.retention_days', 'Analytics retention', 'How many days of analytics history are visible.',
+ 'limit', 'days', NULL, NULL, 30, 0, 'analytics', 0, NULL, 20, 1),
+('analytics.export_csv', 'CSV export', 'Analytics CSV export.',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'analytics', 0, NULL, 30, 1),
+('analytics.geo_country', 'Country geolocation', 'Country-level click geolocation (MaxMind, gated).',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'analytics', 0, NULL, 40, 1),
+('api.bulk_endpoints', 'Bulk API endpoints', 'Bulk create/update API endpoints.',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'api', 0, NULL, 30, 1),
+('qr.scan_attribution', 'QR scan attribution', 'Scan-source attribution analytics for dynamic QR codes.',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'qr', 0, NULL, 20, 1),
+('linkspage.all_templates', 'All LinksPage templates', 'Access to the full system template library (vs starter subset).',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'linkspage', 0, NULL, 20, 1),
+('linkspage.custom_domain', 'LinksPage custom domain', 'Serve a LinksPage on a verified custom domain.',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'linkspage', 0, NULL, 30, 1),
+('linkspage.agegate', 'LinksPage age verification', 'Age-verification gate on LinksPages.',
+ 'boolean', NULL, NULL, 0, NULL, 0, 'linkspage', 0, NULL, 50, 1),
+('org.seats', 'Team seats', 'Maximum users per organisation.',
+ 'limit', 'seats', NULL, NULL, 1, 0, 'org', 0, NULL, 10, 1),
+('clicks.tracked_per_month', 'Tracked clicks per month', 'Metering dimension for click-based PAYG (not gated at launch).',
+ 'quota', 'clicks', 'month', NULL, NULL, 1, 'analytics', 1, NULL, 50, 1),
+('qr.scans_per_month', 'QR scans per month', 'Metering dimension for scan-based PAYG (not gated at launch).',
+ 'quota', 'scans', 'month', NULL, NULL, 1, 'qr', 1, NULL, 30, 1)
+ON DUPLICATE KEY UPDATE
+    `featureDescription` = VALUES(`featureDescription`);
+
+-- -----------------------------------------------------------------------------
+-- 3. Backfill tblTierFeatures from the legacy hard-coded columns.
+-- One INSERT…SELECT per legacy column: every ROW of tblSubscriptionTiers ×
+-- that column becomes one tier-feature row. Idempotent via the UQ_tierfeature
+-- unique key + ON DUPLICATE KEY no-op (an operator's later edits are never
+-- overwritten by a re-run). Legacy NULL on max* columns = unlimited →
+-- isUnlimited=1 with valueInt NULL, preserving exact semantics.
+-- -----------------------------------------------------------------------------
+
+-- maxLinks → links.max
+INSERT INTO `tblTierFeatures` (`tierID`, `featureUID`, `valueInt`, `isUnlimited`)
+SELECT t.`tierID`, f.`featureUID`, t.`maxLinks`,
+       CASE WHEN t.`maxLinks` IS NULL THEN 1 ELSE 0 END
+FROM   `tblSubscriptionTiers` t
+JOIN   `tblFeatures` f ON f.`legacyColumn` = 'maxLinks'
+ON DUPLICATE KEY UPDATE `tierFeatureUID` = `tblTierFeatures`.`tierFeatureUID`;
+
+-- maxCustomDomains → domains.custom_max
+INSERT INTO `tblTierFeatures` (`tierID`, `featureUID`, `valueInt`, `isUnlimited`)
+SELECT t.`tierID`, f.`featureUID`, t.`maxCustomDomains`,
+       CASE WHEN t.`maxCustomDomains` IS NULL THEN 1 ELSE 0 END
+FROM   `tblSubscriptionTiers` t
+JOIN   `tblFeatures` f ON f.`legacyColumn` = 'maxCustomDomains'
+ON DUPLICATE KEY UPDATE `tierFeatureUID` = `tblTierFeatures`.`tierFeatureUID`;
+
+-- maxAPIRequestsPerDay → api.requests_per_day
+INSERT INTO `tblTierFeatures` (`tierID`, `featureUID`, `valueInt`, `isUnlimited`)
+SELECT t.`tierID`, f.`featureUID`, t.`maxAPIRequestsPerDay`,
+       CASE WHEN t.`maxAPIRequestsPerDay` IS NULL THEN 1 ELSE 0 END
+FROM   `tblSubscriptionTiers` t
+JOIN   `tblFeatures` f ON f.`legacyColumn` = 'maxAPIRequestsPerDay'
+ON DUPLICATE KEY UPDATE `tierFeatureUID` = `tblTierFeatures`.`tierFeatureUID`;
+
+-- maxLinksPages → linkspage.pages_max
+INSERT INTO `tblTierFeatures` (`tierID`, `featureUID`, `valueInt`, `isUnlimited`)
+SELECT t.`tierID`, f.`featureUID`, t.`maxLinksPages`,
+       CASE WHEN t.`maxLinksPages` IS NULL THEN 1 ELSE 0 END
+FROM   `tblSubscriptionTiers` t
+JOIN   `tblFeatures` f ON f.`legacyColumn` = 'maxLinksPages'
+ON DUPLICATE KEY UPDATE `tierFeatureUID` = `tblTierFeatures`.`tierFeatureUID`;
+
+-- hasAdvancedRedirects → redirects.advanced (umbrella)
+INSERT INTO `tblTierFeatures` (`tierID`, `featureUID`, `valueBoolean`)
+SELECT t.`tierID`, f.`featureUID`, t.`hasAdvancedRedirects`
+FROM   `tblSubscriptionTiers` t
+JOIN   `tblFeatures` f ON f.`legacyColumn` = 'hasAdvancedRedirects'
+ON DUPLICATE KEY UPDATE `tierFeatureUID` = `tblTierFeatures`.`tierFeatureUID`;
+
+-- hasAnalytics → analytics.enabled
+INSERT INTO `tblTierFeatures` (`tierID`, `featureUID`, `valueBoolean`)
+SELECT t.`tierID`, f.`featureUID`, t.`hasAnalytics`
+FROM   `tblSubscriptionTiers` t
+JOIN   `tblFeatures` f ON f.`legacyColumn` = 'hasAnalytics'
+ON DUPLICATE KEY UPDATE `tierFeatureUID` = `tblTierFeatures`.`tierFeatureUID`;
+
+-- hasQRCodes → qr.dynamic
+INSERT INTO `tblTierFeatures` (`tierID`, `featureUID`, `valueBoolean`)
+SELECT t.`tierID`, f.`featureUID`, t.`hasQRCodes`
+FROM   `tblSubscriptionTiers` t
+JOIN   `tblFeatures` f ON f.`legacyColumn` = 'hasQRCodes'
+ON DUPLICATE KEY UPDATE `tierFeatureUID` = `tblTierFeatures`.`tierFeatureUID`;
+
+-- hasAPIAccess → api.access
+INSERT INTO `tblTierFeatures` (`tierID`, `featureUID`, `valueBoolean`)
+SELECT t.`tierID`, f.`featureUID`, t.`hasAPIAccess`
+FROM   `tblSubscriptionTiers` t
+JOIN   `tblFeatures` f ON f.`legacyColumn` = 'hasAPIAccess'
+ON DUPLICATE KEY UPDATE `tierFeatureUID` = `tblTierFeatures`.`tierFeatureUID`;
+
+-- hasPrioritySupport → support.priority
+INSERT INTO `tblTierFeatures` (`tierID`, `featureUID`, `valueBoolean`)
+SELECT t.`tierID`, f.`featureUID`, t.`hasPrioritySupport`
+FROM   `tblSubscriptionTiers` t
+JOIN   `tblFeatures` f ON f.`legacyColumn` = 'hasPrioritySupport'
+ON DUPLICATE KEY UPDATE `tierFeatureUID` = `tblTierFeatures`.`tierFeatureUID`;
+
+-- hasCustomHTML → linkspage.custom_html
+INSERT INTO `tblTierFeatures` (`tierID`, `featureUID`, `valueBoolean`)
+SELECT t.`tierID`, f.`featureUID`, t.`hasCustomHTML`
+FROM   `tblSubscriptionTiers` t
+JOIN   `tblFeatures` f ON f.`legacyColumn` = 'hasCustomHTML'
+ON DUPLICATE KEY UPDATE `tierFeatureUID` = `tblTierFeatures`.`tierFeatureUID`;

--- a/web/_sql/seeds/019_pricing_settings.sql
+++ b/web/_sql/seeds/019_pricing_settings.sql
@@ -1,0 +1,86 @@
+-- Copyright (c) 2024–2026 MWBM Partners Ltd (MWservices).
+-- All rights reserved.
+--
+-- This source code is proprietary and confidential.
+-- Unauthorised copying, modification, or distribution is strictly prohibited.
+
+-- =============================================================================
+-- Go2My.Link — Pricing Engine: Master Switch + Secondary Settings (all OFF)
+-- =============================================================================
+-- Requirement satisfied: "Everything additive and DISABLED by default (a
+-- billing.pricing_engine_enabled style setting; no behaviour change until
+-- switched on)." Idempotent inserts into the existing tblSettings table —
+-- ON DUPLICATE KEY UPDATE refreshes descriptions only and NEVER clobbers an
+-- operator's chosen settingValue (matches the seed/migration house pattern,
+-- e.g. web/_sql/seeds/017_geolocation_settings.sql).
+--
+-- Every switch below seeds '0' (OFF) except the two currency/region defaults,
+-- which are informational display defaults, not behaviour switches:
+--
+--   billing.pricing_engine_enabled   — MASTER switch. OFF (0) = entitlements.php
+--     resolves tiers from the legacy tblSubscriptionTiers has*/max* columns
+--     exactly as before this phase — web/_sql/schema/036_pricing_engine.sql's
+--     tables are completely inert. ON (1) = web/_functions/pricing.php
+--     resolves entitlements from tblFeatures + tblTierFeatures +
+--     tblOrgFeatureOverrides (fail-open contract preserved throughout).
+--   billing.payg_enabled             — pay-as-you-go / PAYG-capped plans.
+--   billing.usage_metering_enabled   — writes to tblUsageCounters (can run ON
+--     ahead of PAYG launch purely to gather baseline usage, no billing effect).
+--   billing.usage_event_log_enabled  — the optional fine-grained tblUsageEvents
+--     audit ledger, independent of counter metering.
+--   billing.usage_event_retention_days — retention window for that ledger
+--     (default 90; only meaningful once event logging is switched on).
+--   billing.lifetime_plans_enabled   — offering planType='lifetime' price plans.
+--   billing.coupon_stacking_enabled  — master permission for combining coupons
+--     (per-coupon isStackable/stackingGroup still apply underneath).
+--   billing.default_currency / billing.default_region — GBP/GB display
+--     defaults for the price book; not behaviour switches, safe to seed a
+--     real value rather than '0'.
+--
+-- @package    Go2My.Link
+-- @subpackage Seeds
+-- @version    1.0.0
+-- @since      v1.6.0 — Pricing Engine phase (scaffold)
+--
+-- 📖 References:
+--     - Tables:          web/_sql/schema/036_pricing_engine.sql
+--     - Feature/backfill: web/_sql/seeds/018_pricing_feature_registry.sql
+--     - Resolver:         web/_functions/pricing.php
+-- =============================================================================
+
+USE `mwtools_Go2MyLink`;
+
+INSERT INTO `tblSettings` (
+    `settingID`, `settingScope`, `settingScopeRef`,
+    `settingValue`, `settingDefault`, `settingDescription`,
+    `settingDataType`, `isSensitive`, `isEditable`
+) VALUES
+('billing.pricing_engine_enabled', 'System', NULL,
+ '0', '0', 'MASTER SWITCH for the flexible pricing/entitlement engine. OFF (0) = entitlements.php resolves tiers from the legacy tblSubscriptionTiers has*/max* columns exactly as before — the new tables are completely inert. ON (1) = web/_functions/pricing.php resolves entitlements from tblFeatures + tblTierFeatures + tblOrgFeatureOverrides (fail-open contract preserved).',
+ 'boolean', 0, 1),
+('billing.payg_enabled', 'System', NULL,
+ '0', '0', 'Enables pay-as-you-go and PAYG-capped price plans (planType payg / payg_capped). OFF by default — requires usage metering proven in production first.',
+ 'boolean', 0, 1),
+('billing.usage_metering_enabled', 'System', NULL,
+ '0', '0', 'Enables writing usage to tblUsageCounters (and, when event logging is also on, tblUsageEvents). Can run ON ahead of PAYG launch to gather baseline usage with no billing effect.',
+ 'boolean', 0, 1),
+('billing.usage_event_log_enabled', 'System', NULL,
+ '0', '0', 'Enables the fine-grained tblUsageEvents audit ledger in addition to counters. Independent of counter metering; counters alone are sufficient for quotas and PAYG maths.',
+ 'boolean', 0, 1),
+('billing.usage_event_retention_days', 'System', NULL,
+ '90', '90', 'How many days of tblUsageEvents rows to retain; older rows are swept by a probabilistic (1-in-100 request) prune, mirroring api.request_log_retention_days.',
+ 'integer', 0, 1),
+('billing.lifetime_plans_enabled', 'System', NULL,
+ '0', '0', 'Enables offering lifetime price plans (planType lifetime). OFF by default pending owner decision on founding-member deals.',
+ 'boolean', 0, 1),
+('billing.coupon_stacking_enabled', 'System', NULL,
+ '0', '0', 'Master permission for combining multiple coupons on one purchase (per-coupon isStackable/stackingGroup still apply). OFF = one coupon per purchase, full stop.',
+ 'boolean', 0, 1),
+('billing.default_currency', 'System', NULL,
+ 'GBP', 'GBP', 'Default ISO 4217 currency for the price book and pricing page.',
+ 'string', 0, 1),
+('billing.default_region', 'System', NULL,
+ 'GB', 'GB', 'Default region code used to select regional price-plan variants when no better match applies.',
+ 'string', 0, 1)
+ON DUPLICATE KEY UPDATE
+    `settingDescription` = VALUES(`settingDescription`);


### PR DESCRIPTION
## 📋 Summary

Builds the **extremely-flexible pricing/entitlement engine** the owner asked for — **additive and DISABLED by default** (nothing changes runtime behaviour until `billing.pricing_engine_enabled` is switched on). Replaces the fixed `has*`/`max*` tier columns with a data-driven model so we can add **unlimited tiers, unlimited features, and unlimited price structures** without further schema changes.

Design produced by a Fable planning pass; implemented per `pricing_scaffold_plan.md`. Companion strategy doc: **`Pricing_Strategy.md`** (tier names + GBP prices are marked **DRAFT pending owner sign-off**).

## 🔄 What's included (all additive)

- **`web/_sql/schema/036_pricing_engine.sql`** — feature registry (`tblFeatures`), tier↔feature entitlements (typed values), per-org overrides/add-ons, a multi-plan **price book** (`recurring` / `lifetime` / `one_off` / `payg` / **`payg_capped`** pegged to an equivalent flat tier), coupons + redemptions (intro/limited-time/lifetime/first-N, stacking), subscription price-pins (grandfathering), and usage metering (counters/credits/events) — plus a verification view.
- **`web/_sql/migrations/020_pricing_engine.sql`** — idempotent additive migration for deployed DBs.
- **Seeds** — feature registry, `billing.*` settings **all seeded OFF**, and an `INSERT…SELECT` backfill from the legacy `has*/max*` columns so existing tiers keep working.
- **`web/_functions/pricing.php`** — resolver that merges tier defaults + tier features + org overrides, preserving the `entitlements.php` contract & fail-open behaviour.
- **Guarded hooks** — minimal, dead-code-while-disabled additions to `entitlements.php` and `web/_includes/page_init.php`.
- **Tests** for the resolver.

## 🛡️ Safety

- `CREATE TABLE IF NOT EXISTS` only; **no `DROP`/destructive `ALTER`** of existing tables.
- All `billing.*` settings default OFF; price plans default inactive.
- `entitlements.php` behaviour is **unchanged while the flag is OFF** (the new path is dead code inside the existing try/catch).

## ✅ Testing

- Unit suite must stay green (528+); the **advisory integration job imports `036_pricing_engine.sql`** end-to-end on `mysql:8` — that's the schema-correctness gate for this PR.

## 🧑‍✈️ Owner sign-off before ENABLING (not before merging this disabled scaffolding)

Final tier names/slugs, GBP price points, custom-HTML tier placement, payment provider, VAT handling, lifetime-deal, and the enable sequence — listed at the end of `Pricing_Strategy.md`.

## 🔗 Related

Builds on the entitlement layer #146; relates to billing #57–#60.

---

> Tracked on the [Go2My.Link Project Board](https://github.com/orgs/MWBMPartners/projects/4)

---
_Generated by [Claude Code](https://claude.ai/code/session_019v28sGYqnGeBSPNbGgVwgJ)_