### PR TITLE
feat(gdpr): scheduled-jobs engine — execute deletion (#163) + enforce retention (#167), safe-by-default

### DIFF
--- a/tests/integration/cron_deletion_job_test.php
+++ b/tests/integration/cron_deletion_job_test.php
@@ -1,0 +1,624 @@
+<?php
+/**
+ * Copyright (c) 2024–2026 MWBM Partners Ltd (MWservices).
+ * All rights reserved.
+ *
+ * This source code is proprietary and confidential.
+ * Unauthorised copying, modification, or distribution is strictly prohibited.
+ */
+
+/**
+ * ============================================================================
+ * 🧪 Integration tests — #163 GDPR deletion executor (web/_functions/cron.php)
+ * ============================================================================
+ *
+ * Drives the REAL g2ml_cronRunDeletionJob() (and, through it, the existing,
+ * UNMODIFIED g2ml_processDataDeletion()/g2ml_anonymiseUserData() from
+ * data_rights.php) against a freshly imported test database, proving every
+ * safety interlock (I1–I11, see cron.php's own docblock) actually holds at
+ * runtime, not merely in the pure unit tests:
+ *
+ *   - the master enable gate is a true no-op when off (row untouched);
+ *   - dry-run mode logs candidates and touches NOTHING (no anonymisation, no
+ *     status change);
+ *   - a live run anonymises the subject, marks the request completed, and
+ *     stamps the configured actor + timestamp;
+ *   - re-running a completed request is a safe no-op (idempotency, I8);
+ *   - a request still inside its grace window is never selected (I6);
+ *   - an unset/invalid actor UID refuses the ENTIRE run before touching any
+ *     row (I5);
+ *   - the batch cap bounds a single run (I10);
+ *   - an 'export'-type request is never selected, no matter how old (I6's
+ *     WHERE clause, not post-filtering).
+ *
+ * Registration model mirrors settings_scope_dedupe_test.php / activity_log_
+ * test.php: this file registers its cases at INCLUDE time using the $db
+ * handle from run_integration.php's script scope. Helper names are prefixed
+ * g2ml_cronjob_test_* to stay unique alongside sibling integration files.
+ * With no reachable test DB the runner skips before this file is ever
+ * included.
+ *
+ * Every scenario creates its own fresh, uniquely-marked user(s) and request
+ * row(s), and cleans them up at the end — repeatable against a persisted DB,
+ * and independent of any other test file's rows (#148's lesson).
+ *
+ * @package    Go2My.Link
+ * @subpackage Tests
+ * @since      v1.7.0 — GDPR Scheduled Jobs (#163, #167)
+ * ============================================================================
+ */
+
+declare(strict_types=1);
+
+// ----------------------------------------------------------------------------
+// $db is provided by run_integration.php's script scope (a connected mysqli).
+// If it is somehow unavailable, register nothing rather than fataling.
+// ----------------------------------------------------------------------------
+if (!isset($db) || !($db instanceof mysqli))
+{
+    return;
+}
+
+// ----------------------------------------------------------------------------
+// Point the application DB layer (getDB) at the same throwaway server. Each
+// constant is guarded individually so this file composes with any sibling
+// integration file that already defined them.
+// ----------------------------------------------------------------------------
+if (!defined('DB_HOST'))
+{
+    $g2mlCronJobTestHost = getenv('G2ML_TEST_DB_HOST');
+
+    if ($g2mlCronJobTestHost === false || $g2mlCronJobTestHost === '')
+    {
+        $g2mlCronJobTestHost = '127.0.0.1';
+    }
+
+    define('DB_HOST', $g2mlCronJobTestHost);
+}
+
+if (!defined('DB_PORT'))
+{
+    $g2mlCronJobTestPortRaw = getenv('G2ML_TEST_DB_PORT');
+
+    if ($g2mlCronJobTestPortRaw === false || $g2mlCronJobTestPortRaw === '')
+    {
+        $g2mlCronJobTestPortRaw = '3306';
+    }
+
+    define('DB_PORT', (int) $g2mlCronJobTestPortRaw);
+}
+
+if (!defined('DB_USER'))
+{
+    $g2mlCronJobTestUser = getenv('G2ML_TEST_DB_USER');
+
+    if ($g2mlCronJobTestUser === false || $g2mlCronJobTestUser === '')
+    {
+        $g2mlCronJobTestUser = 'root';
+    }
+
+    define('DB_USER', $g2mlCronJobTestUser);
+}
+
+if (!defined('DB_PASS'))
+{
+    $g2mlCronJobTestPass = getenv('G2ML_TEST_DB_PASS');
+
+    if ($g2mlCronJobTestPass === false)
+    {
+        $g2mlCronJobTestPass = '';
+    }
+
+    define('DB_PASS', $g2mlCronJobTestPass);
+}
+
+if (!defined('DB_NAME'))
+{
+    $g2mlCronJobTestName = getenv('G2ML_TEST_DB_NAME');
+
+    if ($g2mlCronJobTestName === false || $g2mlCronJobTestName === '')
+    {
+        $g2mlCronJobTestName = 'mwtools_Go2MyLink';
+    }
+
+    define('DB_NAME', $g2mlCronJobTestName);
+}
+
+if (!defined('DB_CHARSET'))
+{
+    define('DB_CHARSET', 'utf8mb4');
+}
+
+// ----------------------------------------------------------------------------
+// Load the real application function files the code under test depends on.
+// cron.php's own functions call getSetting()/logActivity() UNGUARDED (unlike
+// data_export_test.php's target, which guards every optional collaborator),
+// so settings.php and activity_logger.php MUST both be loaded here.
+// ----------------------------------------------------------------------------
+$g2mlCronJobFunctionsDir = dirname(__DIR__, 2) . '/web/_functions';
+
+require_once $g2mlCronJobFunctionsDir . '/db_connect.php';
+require_once $g2mlCronJobFunctionsDir . '/db_query.php';
+require_once $g2mlCronJobFunctionsDir . '/security.php';
+require_once $g2mlCronJobFunctionsDir . '/settings.php';
+require_once $g2mlCronJobFunctionsDir . '/activity_logger.php';
+require_once $g2mlCronJobFunctionsDir . '/data_rights.php';
+require_once $g2mlCronJobFunctionsDir . '/cron.php';
+
+// ----------------------------------------------------------------------------
+// Small DB helpers (prepared statements throughout).
+// ----------------------------------------------------------------------------
+
+/**
+ * Execute a setup/teardown query, aborting loudly on failure.
+ *
+ * @param  mysqli $db
+ * @param  string $sql
+ * @return void
+ */
+function g2ml_cronjob_test_exec(mysqli $db, string $sql): void
+{
+    $result = mysqli_query($db, $sql);
+
+    if ($result === false)
+    {
+        throw new RuntimeException('Setup query failed: ' . mysqli_error($db) . ' — SQL: ' . $sql);
+    }
+}
+
+/**
+ * Insert a throwaway, active user in the [default] org and return its userUID.
+ *
+ * @param  mysqli $db
+ * @param  string $marker
+ * @return int
+ */
+function g2ml_cronjob_test_insert_user(mysqli $db, string $marker): int
+{
+    $statement = mysqli_prepare(
+        $db,
+        'INSERT INTO `tblUsers` (`orgHandle`, `username`, `email`, `passwordHash`, `firstName`, `lastName`, `isActive`) '
+        . 'VALUES (\'[default]\', ?, ?, ?, ?, ?, 1)'
+    );
+
+    $username     = $marker;
+    $email        = $marker . '@cronjob163.test';
+    $passwordHash = 'x';
+    $firstName    = 'Cron';
+    $lastName     = 'Tester';
+
+    mysqli_stmt_bind_param($statement, 'sssss', $username, $email, $passwordHash, $firstName, $lastName);
+    $ok = mysqli_stmt_execute($statement);
+
+    if ($ok === false)
+    {
+        $error = mysqli_stmt_error($statement);
+        mysqli_stmt_close($statement);
+        throw new RuntimeException('Insert (user) failed: ' . $error);
+    }
+
+    $userUID = (int) mysqli_stmt_insert_id($statement);
+    mysqli_stmt_close($statement);
+
+    return $userUID;
+}
+
+/**
+ * Insert a tblDataDeletionRequests row with a caller-controlled createdAt
+ * (expressed as "days ago" so tests can place a row inside or outside the
+ * grace window) and return its requestUID.
+ *
+ * @param  mysqli $db
+ * @param  int    $userUID
+ * @param  string $requestType  'deletion' | 'export'.
+ * @param  string $status       'pending' | 'processing' | 'completed' | 'rejected'.
+ * @param  int    $daysAgo      How many days in the past createdAt is set to.
+ * @return int
+ */
+function g2ml_cronjob_test_insert_request(mysqli $db, int $userUID, string $requestType, string $status, int $daysAgo): int
+{
+    $createdAt = gmdate('Y-m-d H:i:s', time() - ($daysAgo * 86400));
+
+    $statement = mysqli_prepare(
+        $db,
+        'INSERT INTO `tblDataDeletionRequests` (`userUID`, `requestType`, `status`, `createdAt`) '
+        . 'VALUES (?, ?, ?, ?)'
+    );
+
+    mysqli_stmt_bind_param($statement, 'isss', $userUID, $requestType, $status, $createdAt);
+    $ok = mysqli_stmt_execute($statement);
+
+    if ($ok === false)
+    {
+        $error = mysqli_stmt_error($statement);
+        mysqli_stmt_close($statement);
+        throw new RuntimeException('Insert (deletion request) failed: ' . $error);
+    }
+
+    $requestUID = (int) mysqli_stmt_insert_id($statement);
+    mysqli_stmt_close($statement);
+
+    return $requestUID;
+}
+
+/**
+ * Read back a tblDataDeletionRequests row by requestUID.
+ *
+ * @param  mysqli $db
+ * @param  int    $requestUID
+ * @return array<string, mixed>|null
+ */
+function g2ml_cronjob_test_fetch_request(mysqli $db, int $requestUID): ?array
+{
+    $statement = mysqli_prepare(
+        $db,
+        'SELECT `status`, `processedByUserUID`, `processedAt` FROM `tblDataDeletionRequests` WHERE `requestUID` = ? LIMIT 1'
+    );
+    mysqli_stmt_bind_param($statement, 'i', $requestUID);
+    mysqli_stmt_execute($statement);
+    $result = mysqli_stmt_get_result($statement);
+    $row    = mysqli_fetch_assoc($result);
+    mysqli_free_result($result);
+    mysqli_stmt_close($statement);
+
+    if ($row === null)
+    {
+        return null;
+    }
+
+    return $row;
+}
+
+/**
+ * Read back a tblUsers row by userUID (the fields g2ml_anonymiseUserData()
+ * mutates).
+ *
+ * @param  mysqli $db
+ * @param  int    $userUID
+ * @return array<string, mixed>|null
+ */
+function g2ml_cronjob_test_fetch_user(mysqli $db, int $userUID): ?array
+{
+    $statement = mysqli_prepare(
+        $db,
+        'SELECT `email`, `firstName`, `lastName`, `isActive` FROM `tblUsers` WHERE `userUID` = ? LIMIT 1'
+    );
+    mysqli_stmt_bind_param($statement, 'i', $userUID);
+    mysqli_stmt_execute($statement);
+    $result = mysqli_stmt_get_result($statement);
+    $row    = mysqli_fetch_assoc($result);
+    mysqli_free_result($result);
+    mysqli_stmt_close($statement);
+
+    if ($row === null)
+    {
+        return null;
+    }
+
+    return $row;
+}
+
+/**
+ * Count tblActivityLog rows for a given logAction + userUID.
+ *
+ * @param  mysqli $db
+ * @param  string $logAction
+ * @param  int    $userUID
+ * @return int
+ */
+function g2ml_cronjob_test_count_activity(mysqli $db, string $logAction, int $userUID): int
+{
+    $statement = mysqli_prepare(
+        $db,
+        'SELECT COUNT(*) AS cnt FROM `tblActivityLog` WHERE `logAction` = ? AND `userUID` = ?'
+    );
+    mysqli_stmt_bind_param($statement, 'si', $logAction, $userUID);
+    mysqli_stmt_execute($statement);
+    $result = mysqli_stmt_get_result($statement);
+    $row    = mysqli_fetch_assoc($result);
+    mysqli_free_result($result);
+    mysqli_stmt_close($statement);
+
+    return (int) $row['cnt'];
+}
+
+/**
+ * Delete every row this test file may have created for a userUID, in
+ * FK-safe order. Safe to call even when some rows were never created.
+ *
+ * @param  mysqli $db
+ * @param  int    $userUID
+ * @return void
+ */
+function g2ml_cronjob_test_cleanup(mysqli $db, int $userUID): void
+{
+    $deleteRequestsStatement = mysqli_prepare(
+        $db,
+        'DELETE FROM `tblDataDeletionRequests` WHERE `userUID` = ? OR `processedByUserUID` = ?'
+    );
+    mysqli_stmt_bind_param($deleteRequestsStatement, 'ii', $userUID, $userUID);
+    mysqli_stmt_execute($deleteRequestsStatement);
+    mysqli_stmt_close($deleteRequestsStatement);
+
+    $deleteActivityStatement = mysqli_prepare($db, 'DELETE FROM `tblActivityLog` WHERE `userUID` = ?');
+    mysqli_stmt_bind_param($deleteActivityStatement, 'i', $userUID);
+    mysqli_stmt_execute($deleteActivityStatement);
+    mysqli_stmt_close($deleteActivityStatement);
+
+    $deleteSessionsStatement = mysqli_prepare($db, 'DELETE FROM `tblUserSessions` WHERE `userUID` = ?');
+    mysqli_stmt_bind_param($deleteSessionsStatement, 'i', $userUID);
+    mysqli_stmt_execute($deleteSessionsStatement);
+    mysqli_stmt_close($deleteSessionsStatement);
+
+    $deleteConsentStatement = mysqli_prepare($db, 'DELETE FROM `tblConsentRecords` WHERE `userUID` = ?');
+    mysqli_stmt_bind_param($deleteConsentStatement, 'i', $userUID);
+    mysqli_stmt_execute($deleteConsentStatement);
+    mysqli_stmt_close($deleteConsentStatement);
+
+    $deleteUserStatement = mysqli_prepare($db, 'DELETE FROM `tblUsers` WHERE `userUID` = ?');
+    mysqli_stmt_bind_param($deleteUserStatement, 'i', $userUID);
+    mysqli_stmt_execute($deleteUserStatement);
+    mysqli_stmt_close($deleteUserStatement);
+}
+
+// ----------------------------------------------------------------------------
+// Ensure the [default] org + free tier exist (FK targets for tblUsers).
+// ----------------------------------------------------------------------------
+g2ml_cronjob_test_exec(
+    $db,
+    "INSERT INTO `tblSubscriptionTiers` (`tierID`, `tierName`) "
+    . "VALUES ('free', 'Free') "
+    . "ON DUPLICATE KEY UPDATE `tierName` = VALUES(`tierName`)"
+);
+
+g2ml_cronjob_test_exec(
+    $db,
+    "INSERT INTO `tblOrganisations` (`orgHandle`, `orgName`, `orgFallbackURL`, `tierID`, `isActive`) "
+    . "VALUES ('[default]', 'Default Test Org', 'https://go2my.link/fallback', 'free', 1) "
+    . "ON DUPLICATE KEY UPDATE `orgFallbackURL` = VALUES(`orgFallbackURL`)"
+);
+
+// ============================================================================
+// (1) Disabled gate — the job is a total no-op.
+// ============================================================================
+test('cron deletion job (#163): disabled gate — report {enabled:false}, row untouched', function () use ($db): void
+{
+    $marker     = 'cronjob163_disabled_' . substr(hash('sha256', (string) microtime(true)), 0, 12);
+    $userUID    = g2ml_cronjob_test_insert_user($db, $marker);
+    $requestUID = g2ml_cronjob_test_insert_request($db, $userUID, 'deletion', 'pending', 35);
+
+    setSetting('gdpr.deletion_job_enabled', false, 'System');
+    setSetting('gdpr.deletion_job_dry_run', true, 'System');
+
+    $report = g2ml_cronRunDeletionJob(30);
+
+    assert_same(false, $report['enabled'], 'A disabled job reports enabled:false');
+
+    $requestRow = g2ml_cronjob_test_fetch_request($db, $requestUID);
+    assert_same('pending', $requestRow['status'], 'The request row is completely untouched while disabled');
+
+    g2ml_cronjob_test_cleanup($db, $userUID);
+});
+
+// ============================================================================
+// (2) Dry-run — logs candidates, touches NOTHING.
+// ============================================================================
+test('cron deletion job (#163): dry-run logs the candidate and changes nothing', function () use ($db): void
+{
+    $marker     = 'cronjob163_dryrun_' . substr(hash('sha256', (string) microtime(true)), 0, 12);
+    $userUID    = g2ml_cronjob_test_insert_user($db, $marker);
+    $requestUID = g2ml_cronjob_test_insert_request($db, $userUID, 'deletion', 'pending', 35);
+
+    setSetting('gdpr.deletion_job_enabled', true, 'System');
+    setSetting('gdpr.deletion_job_dry_run', true, 'System');
+    setSetting('gdpr.deletion_job_batch', 10, 'System');
+
+    $report = g2ml_cronRunDeletionJob(30);
+
+    assert_same(true, $report['enabled'], 'Dry-run is still "enabled"');
+    assert_same('dry-run', $report['mode'], 'Mode must be dry-run');
+    assert_true(in_array($requestUID, $report['wouldProcess'], true), 'The due request appears in wouldProcess');
+
+    $requestRow = g2ml_cronjob_test_fetch_request($db, $requestUID);
+    assert_same('pending', $requestRow['status'], 'Dry-run must NOT change the request status');
+
+    $userRow = g2ml_cronjob_test_fetch_user($db, $userUID);
+    assert_same(1, (int) $userRow['isActive'], 'Dry-run must NOT anonymise the user (isActive unchanged)');
+    assert_false(str_contains($userRow['email'], 'anonymised.go2my.link'), 'Dry-run must NOT touch the email');
+
+    $dryRunLogCount = g2ml_cronjob_test_count_activity($db, 'data_deletion_due_dryrun', $userUID);
+    assert_true($dryRunLogCount >= 1, 'A data_deletion_due_dryrun activity row was written');
+
+    g2ml_cronjob_test_cleanup($db, $userUID);
+});
+
+// ============================================================================
+// (3) Live happy path — anonymises the subject, completes the request.
+// ============================================================================
+test('cron deletion job (#163): live run anonymises the subject and completes the request', function () use ($db): void
+{
+    $marker      = 'cronjob163_live_' . substr(hash('sha256', (string) microtime(true)), 0, 12);
+    $actorMarker = 'cronjob163_actor_' . substr(hash('sha256', (string) microtime(true) . 'a'), 0, 12);
+
+    $userUID    = g2ml_cronjob_test_insert_user($db, $marker);
+    $actorUID   = g2ml_cronjob_test_insert_user($db, $actorMarker);
+    $requestUID = g2ml_cronjob_test_insert_request($db, $userUID, 'deletion', 'pending', 35);
+
+    setSetting('gdpr.deletion_job_enabled', true, 'System');
+    setSetting('gdpr.deletion_job_dry_run', false, 'System');
+    setSetting('gdpr.deletion_job_batch', 10, 'System');
+    setSetting('gdpr.deletion_job_actor_uid', $actorUID, 'System');
+
+    $report = g2ml_cronRunDeletionJob(30);
+
+    assert_same('live', $report['mode'], 'Mode must be live');
+    assert_same(1, $report['processed'], 'Exactly one request processed');
+    assert_same(0, $report['failed'], 'No failures');
+
+    $userRow = g2ml_cronjob_test_fetch_user($db, $userUID);
+    assert_same('[DELETED]', $userRow['firstName'], 'firstName anonymised');
+    assert_same('[DELETED]', $userRow['lastName'], 'lastName anonymised');
+    assert_same('deleted_' . $userUID . '@anonymised.go2my.link', $userRow['email'], 'email anonymised to the expected sentinel');
+    assert_same(0, (int) $userRow['isActive'], 'isActive turned off');
+
+    $requestRow = g2ml_cronjob_test_fetch_request($db, $requestUID);
+    assert_same('completed', $requestRow['status'], 'The request row is marked completed');
+    assert_same($actorUID, (int) $requestRow['processedByUserUID'], 'processedByUserUID is the configured actor');
+    assert_true($requestRow['processedAt'] !== null, 'processedAt is stamped');
+
+    $executedLogCount = g2ml_cronjob_test_count_activity($db, 'data_deletion_executed', $userUID);
+    assert_true($executedLogCount >= 1, 'A data_deletion_executed activity row was written');
+
+    g2ml_cronjob_test_cleanup($db, $userUID);
+    g2ml_cronjob_test_cleanup($db, $actorUID);
+});
+
+// ============================================================================
+// (4) Idempotency — running live twice does not reprocess a completed row.
+// ============================================================================
+test('cron deletion job (#163): a second live run is a safe no-op (idempotent)', function () use ($db): void
+{
+    $marker      = 'cronjob163_idem_' . substr(hash('sha256', (string) microtime(true)), 0, 12);
+    $actorMarker = 'cronjob163_idemactor_' . substr(hash('sha256', (string) microtime(true) . 'a'), 0, 12);
+
+    $userUID    = g2ml_cronjob_test_insert_user($db, $marker);
+    $actorUID   = g2ml_cronjob_test_insert_user($db, $actorMarker);
+    $requestUID = g2ml_cronjob_test_insert_request($db, $userUID, 'deletion', 'pending', 35);
+
+    setSetting('gdpr.deletion_job_enabled', true, 'System');
+    setSetting('gdpr.deletion_job_dry_run', false, 'System');
+    setSetting('gdpr.deletion_job_batch', 10, 'System');
+    setSetting('gdpr.deletion_job_actor_uid', $actorUID, 'System');
+
+    $firstReport = g2ml_cronRunDeletionJob(30);
+    assert_same(1, $firstReport['processed'], 'First run processes the one due request');
+
+    $secondReport = g2ml_cronRunDeletionJob(30);
+    assert_same(0, $secondReport['due'], 'Second run finds nothing due — the row is no longer pending');
+    assert_same(0, $secondReport['processed'], 'Second run processes nothing');
+    assert_same(0, $secondReport['failed'], 'Second run has no failures');
+
+    g2ml_cronjob_test_cleanup($db, $userUID);
+    g2ml_cronjob_test_cleanup($db, $actorUID);
+});
+
+// ============================================================================
+// (5) Grace window — a freshly-created request is never selected.
+// ============================================================================
+test('cron deletion job (#163): a request still inside its grace window is never selected', function () use ($db): void
+{
+    $marker     = 'cronjob163_grace_' . substr(hash('sha256', (string) microtime(true)), 0, 12);
+    $userUID    = g2ml_cronjob_test_insert_user($db, $marker);
+    $requestUID = g2ml_cronjob_test_insert_request($db, $userUID, 'deletion', 'pending', 0);
+
+    setSetting('gdpr.deletion_job_enabled', true, 'System');
+    setSetting('gdpr.deletion_job_dry_run', true, 'System');
+    setSetting('gdpr.deletion_job_batch', 10, 'System');
+    setSetting('compliance.data_deletion_grace_days', 30, 'System');
+
+    $report = g2ml_cronRunDeletionJob(30);
+
+    assert_false(in_array($requestUID, $report['wouldProcess'], true), 'A request created "now" must not be due under a 30-day grace window');
+
+    $requestRow = g2ml_cronjob_test_fetch_request($db, $requestUID);
+    assert_same('pending', $requestRow['status'], 'The request row remains untouched');
+
+    g2ml_cronjob_test_cleanup($db, $userUID);
+});
+
+// ============================================================================
+// (6) Actor unset/invalid — live run refuses to start, zero rows touched.
+// ============================================================================
+test('cron deletion job (#163): an unset actor UID refuses the entire live run', function () use ($db): void
+{
+    $marker     = 'cronjob163_noactor_' . substr(hash('sha256', (string) microtime(true)), 0, 12);
+    $userUID    = g2ml_cronjob_test_insert_user($db, $marker);
+    $requestUID = g2ml_cronjob_test_insert_request($db, $userUID, 'deletion', 'pending', 35);
+
+    setSetting('gdpr.deletion_job_enabled', true, 'System');
+    setSetting('gdpr.deletion_job_dry_run', false, 'System');
+    setSetting('gdpr.deletion_job_batch', 10, 'System');
+    setSetting('gdpr.deletion_job_actor_uid', null, 'System');
+
+    $report = g2ml_cronRunDeletionJob(30);
+
+    assert_same('actor_not_configured', $report['error'], 'The report surfaces the actor_not_configured error');
+
+    $requestRow = g2ml_cronjob_test_fetch_request($db, $requestUID);
+    assert_same('pending', $requestRow['status'], 'Zero rows touched when the actor is unset');
+
+    $userRow = g2ml_cronjob_test_fetch_user($db, $userUID);
+    assert_same(1, (int) $userRow['isActive'], 'The user was never anonymised');
+
+    g2ml_cronjob_test_cleanup($db, $userUID);
+});
+
+// ============================================================================
+// (7) Batch cap — bounds a single run.
+// ============================================================================
+test('cron deletion job (#163): the batch cap bounds a single run to exactly one processed row', function () use ($db): void
+{
+    $markerPrefix = 'cronjob163_batch_' . substr(hash('sha256', (string) microtime(true)), 0, 10);
+    $actorMarker  = 'cronjob163_batchactor_' . substr(hash('sha256', (string) microtime(true) . 'a'), 0, 12);
+
+    $actorUID = g2ml_cronjob_test_insert_user($db, $actorMarker);
+
+    $userUIDs = [];
+
+    for ($index = 0; $index < 3; $index++)
+    {
+        $userUID              = g2ml_cronjob_test_insert_user($db, $markerPrefix . '_' . $index);
+        $userUIDs[]            = $userUID;
+        g2ml_cronjob_test_insert_request($db, $userUID, 'deletion', 'pending', 35);
+    }
+
+    setSetting('gdpr.deletion_job_enabled', true, 'System');
+    setSetting('gdpr.deletion_job_dry_run', false, 'System');
+    setSetting('gdpr.deletion_job_batch', 1, 'System');
+    setSetting('gdpr.deletion_job_actor_uid', $actorUID, 'System');
+
+    $report = g2ml_cronRunDeletionJob(30);
+
+    assert_same(1, $report['processed'], 'Exactly one row processed when the batch cap is 1');
+
+    $pendingRemaining = 0;
+
+    foreach ($userUIDs as $userUID)
+    {
+        $userRow = g2ml_cronjob_test_fetch_user($db, $userUID);
+
+        if ((int) $userRow['isActive'] === 1)
+        {
+            $pendingRemaining = $pendingRemaining + 1;
+        }
+    }
+
+    assert_same(2, $pendingRemaining, 'The other two subjects remain untouched (batch cap respected)');
+
+    foreach ($userUIDs as $userUID)
+    {
+        g2ml_cronjob_test_cleanup($db, $userUID);
+    }
+
+    g2ml_cronjob_test_cleanup($db, $actorUID);
+});
+
+// ============================================================================
+// (8) Export rows are immune — never selected, no matter how old.
+// ============================================================================
+test('cron deletion job (#163): an export-type request is never selected', function () use ($db): void
+{
+    $marker     = 'cronjob163_export_' . substr(hash('sha256', (string) microtime(true)), 0, 12);
+    $userUID    = g2ml_cronjob_test_insert_user($db, $marker);
+    $requestUID = g2ml_cronjob_test_insert_request($db, $userUID, 'export', 'pending', 365);
+
+    setSetting('gdpr.deletion_job_enabled', true, 'System');
+    setSetting('gdpr.deletion_job_dry_run', true, 'System');
+    setSetting('gdpr.deletion_job_batch', 10, 'System');
+
+    $report = g2ml_cronRunDeletionJob(30);
+
+    assert_same(0, $report['due'], 'An export-type row must never be selected by the deletion executor, regardless of age');
+
+    g2ml_cronjob_test_cleanup($db, $userUID);
+});

--- a/tests/integration/cron_retention_test.php
+++ b/tests/integration/cron_retention_test.php
@@ -1,0 +1,729 @@
+<?php
+/**
+ * Copyright (c) 2024–2026 MWBM Partners Ltd (MWservices).
+ * All rights reserved.
+ *
+ * This source code is proprietary and confidential.
+ * Unauthorised copying, modification, or distribution is strictly prohibited.
+ */
+
+/**
+ * ============================================================================
+ * 🧪 Integration tests — #167 retention sweeps (web/_functions/cron.php)
+ * ============================================================================
+ *
+ * Drives the REAL g2ml_cronRunRetentionJob() and its sub-sweeps against a
+ * freshly imported test database:
+ *
+ *   - the master gate (retention.enforcement_enabled) is a true no-op when off;
+ *   - the activity-log ANONYMISE sweep sets ipAddress/requestUserAgent on rows
+ *     past the age threshold, leaves recent rows untouched, and converges to
+ *     zero on a re-run (idempotent);
+ *   - the anonymise sweep loops correctly across multiple small batches;
+ *   - the activity-log PURGE sweep stays off by default and, when enabled with
+ *     a window narrower than the anonymise window, skips itself with a
+ *     logged warning rather than destroying not-yet-anonymised rows;
+ *   - the expired-export sweep unlinks an expired, PATH-CONFINED file and
+ *     NULLs its DB path, leaves an unexpired row+file alone, and — for a
+ *     tampered/escaping path — NEVER unlinks the file but still NULLs the
+ *     path;
+ *   - the session sweep removes an expired session row;
+ *   - the advisory lock genuinely blocks a concurrent acquire from a SECOND
+ *     connection, and releases cleanly afterwards.
+ *
+ * Registration model mirrors cron_deletion_job_test.php / settings_scope_
+ * dedupe_test.php: cases register at INCLUDE time using the $db handle from
+ * run_integration.php's script scope. Helper names are prefixed
+ * g2ml_cronret_test_* to stay unique alongside sibling integration files
+ * (including cron_deletion_job_test.php's own g2ml_cronjob_test_* helpers).
+ * With no reachable test DB the runner skips before this file is ever
+ * included.
+ *
+ * @package    Go2My.Link
+ * @subpackage Tests
+ * @since      v1.7.0 — GDPR Scheduled Jobs (#163, #167)
+ * ============================================================================
+ */
+
+declare(strict_types=1);
+
+// ----------------------------------------------------------------------------
+// $db is provided by run_integration.php's script scope (a connected mysqli).
+// If it is somehow unavailable, register nothing rather than fataling.
+// ----------------------------------------------------------------------------
+if (!isset($db) || !($db instanceof mysqli))
+{
+    return;
+}
+
+// ----------------------------------------------------------------------------
+// Point the application DB layer (getDB) at the same throwaway server. Each
+// constant is guarded individually so this file composes with any sibling
+// integration file that already defined them.
+// ----------------------------------------------------------------------------
+if (!defined('DB_HOST'))
+{
+    $g2mlCronRetTestHost = getenv('G2ML_TEST_DB_HOST');
+
+    if ($g2mlCronRetTestHost === false || $g2mlCronRetTestHost === '')
+    {
+        $g2mlCronRetTestHost = '127.0.0.1';
+    }
+
+    define('DB_HOST', $g2mlCronRetTestHost);
+}
+
+if (!defined('DB_PORT'))
+{
+    $g2mlCronRetTestPortRaw = getenv('G2ML_TEST_DB_PORT');
+
+    if ($g2mlCronRetTestPortRaw === false || $g2mlCronRetTestPortRaw === '')
+    {
+        $g2mlCronRetTestPortRaw = '3306';
+    }
+
+    define('DB_PORT', (int) $g2mlCronRetTestPortRaw);
+}
+
+if (!defined('DB_USER'))
+{
+    $g2mlCronRetTestUser = getenv('G2ML_TEST_DB_USER');
+
+    if ($g2mlCronRetTestUser === false || $g2mlCronRetTestUser === '')
+    {
+        $g2mlCronRetTestUser = 'root';
+    }
+
+    define('DB_USER', $g2mlCronRetTestUser);
+}
+
+if (!defined('DB_PASS'))
+{
+    $g2mlCronRetTestPass = getenv('G2ML_TEST_DB_PASS');
+
+    if ($g2mlCronRetTestPass === false)
+    {
+        $g2mlCronRetTestPass = '';
+    }
+
+    define('DB_PASS', $g2mlCronRetTestPass);
+}
+
+if (!defined('DB_NAME'))
+{
+    $g2mlCronRetTestName = getenv('G2ML_TEST_DB_NAME');
+
+    if ($g2mlCronRetTestName === false || $g2mlCronRetTestName === '')
+    {
+        $g2mlCronRetTestName = 'mwtools_Go2MyLink';
+    }
+
+    define('DB_NAME', $g2mlCronRetTestName);
+}
+
+if (!defined('DB_CHARSET'))
+{
+    define('DB_CHARSET', 'utf8mb4');
+}
+
+// ----------------------------------------------------------------------------
+// g2ml_retentionPurgeExpiredExports() writes/reads under
+// G2ML_UPLOADS . '/exports/'. Point it at a throwaway directory under the
+// system temp path, guarded so this composes with any sibling integration
+// file (e.g. data_export_test.php) that defines it first.
+// ----------------------------------------------------------------------------
+if (!defined('G2ML_UPLOADS'))
+{
+    $g2mlCronRetUploadsDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'g2ml_it_uploads';
+
+    if (!is_dir($g2mlCronRetUploadsDir))
+    {
+        mkdir($g2mlCronRetUploadsDir, 0750, true);
+    }
+
+    define('G2ML_UPLOADS', $g2mlCronRetUploadsDir);
+}
+
+$g2mlCronRetExportsDir = G2ML_UPLOADS . DIRECTORY_SEPARATOR . 'exports';
+
+if (!is_dir($g2mlCronRetExportsDir))
+{
+    mkdir($g2mlCronRetExportsDir, 0750, true);
+}
+
+// ----------------------------------------------------------------------------
+// Load the real application function files the code under test depends on.
+// ----------------------------------------------------------------------------
+$g2mlCronRetFunctionsDir = dirname(__DIR__, 2) . '/web/_functions';
+
+require_once $g2mlCronRetFunctionsDir . '/db_connect.php';
+require_once $g2mlCronRetFunctionsDir . '/db_query.php';
+require_once $g2mlCronRetFunctionsDir . '/security.php';
+require_once $g2mlCronRetFunctionsDir . '/settings.php';
+require_once $g2mlCronRetFunctionsDir . '/activity_logger.php';
+require_once $g2mlCronRetFunctionsDir . '/data_rights.php';
+require_once $g2mlCronRetFunctionsDir . '/session.php';
+require_once $g2mlCronRetFunctionsDir . '/cron.php';
+
+// ----------------------------------------------------------------------------
+// Small DB helpers (prepared statements throughout).
+// ----------------------------------------------------------------------------
+
+/**
+ * Insert a throwaway, active user in the [default] org and return its userUID.
+ * (The retention sweeps under test do not read tblUsers, but tblUserSessions
+ * carries a NOT NULL FK to it.)
+ *
+ * @param  mysqli $db
+ * @param  string $marker
+ * @return int
+ */
+function g2ml_cronret_test_insert_user(mysqli $db, string $marker): int
+{
+    $statement = mysqli_prepare(
+        $db,
+        'INSERT INTO `tblUsers` (`orgHandle`, `username`, `email`, `passwordHash`, `firstName`, `lastName`, `isActive`) '
+        . 'VALUES (\'[default]\', ?, ?, ?, ?, ?, 1)'
+    );
+
+    $username     = $marker;
+    $email        = $marker . '@cronret167.test';
+    $passwordHash = 'x';
+    $firstName    = 'Cron';
+    $lastName     = 'Retention';
+
+    mysqli_stmt_bind_param($statement, 'sssss', $username, $email, $passwordHash, $firstName, $lastName);
+    $ok = mysqli_stmt_execute($statement);
+
+    if ($ok === false)
+    {
+        $error = mysqli_stmt_error($statement);
+        mysqli_stmt_close($statement);
+        throw new RuntimeException('Insert (user) failed: ' . $error);
+    }
+
+    $userUID = (int) mysqli_stmt_insert_id($statement);
+    mysqli_stmt_close($statement);
+
+    return $userUID;
+}
+
+/**
+ * Insert a tblActivityLog row with an explicit createdAt (days ago), ipAddress,
+ * and requestUserAgent, for a given userUID. Returns the logUID.
+ *
+ * @param  mysqli $db
+ * @param  int    $userUID
+ * @param  int    $daysAgo
+ * @param  string $ipAddress
+ * @param  string $userAgent
+ * @return int
+ */
+function g2ml_cronret_test_insert_activity(mysqli $db, int $userUID, int $daysAgo, string $ipAddress, string $userAgent): int
+{
+    $createdAt = gmdate('Y-m-d H:i:s', time() - ($daysAgo * 86400));
+    $logAction = 'cronret167_test_hit';
+
+    $statement = mysqli_prepare(
+        $db,
+        'INSERT INTO `tblActivityLog` (`logAction`, `userUID`, `ipAddress`, `requestUserAgent`, `createdAt`) '
+        . 'VALUES (?, ?, ?, ?, ?)'
+    );
+
+    mysqli_stmt_bind_param($statement, 'sisss', $logAction, $userUID, $ipAddress, $userAgent, $createdAt);
+    $ok = mysqli_stmt_execute($statement);
+
+    if ($ok === false)
+    {
+        $error = mysqli_stmt_error($statement);
+        mysqli_stmt_close($statement);
+        throw new RuntimeException('Insert (activity log) failed: ' . $error);
+    }
+
+    $logUID = (int) mysqli_stmt_insert_id($statement);
+    mysqli_stmt_close($statement);
+
+    return $logUID;
+}
+
+/**
+ * Read back a tblActivityLog row's ipAddress/requestUserAgent by logUID.
+ *
+ * @param  mysqli $db
+ * @param  int    $logUID
+ * @return array<string, mixed>|null
+ */
+function g2ml_cronret_test_fetch_activity(mysqli $db, int $logUID): ?array
+{
+    $statement = mysqli_prepare(
+        $db,
+        'SELECT `ipAddress`, `requestUserAgent` FROM `tblActivityLog` WHERE `logUID` = ? LIMIT 1'
+    );
+    mysqli_stmt_bind_param($statement, 'i', $logUID);
+    mysqli_stmt_execute($statement);
+    $result = mysqli_stmt_get_result($statement);
+    $row    = mysqli_fetch_assoc($result);
+    mysqli_free_result($result);
+    mysqli_stmt_close($statement);
+
+    if ($row === null)
+    {
+        return null;
+    }
+
+    return $row;
+}
+
+/**
+ * Delete every tblActivityLog row for a userUID. Idempotent.
+ *
+ * @param  mysqli $db
+ * @param  int    $userUID
+ * @return void
+ */
+function g2ml_cronret_test_cleanup_activity(mysqli $db, int $userUID): void
+{
+    $statement = mysqli_prepare($db, 'DELETE FROM `tblActivityLog` WHERE `userUID` = ?');
+    mysqli_stmt_bind_param($statement, 'i', $userUID);
+    mysqli_stmt_execute($statement);
+    mysqli_stmt_close($statement);
+}
+
+/**
+ * Delete a user (and, via FK cascade, its sessions/consent rows). Idempotent.
+ *
+ * @param  mysqli $db
+ * @param  int    $userUID
+ * @return void
+ */
+function g2ml_cronret_test_cleanup_user(mysqli $db, int $userUID): void
+{
+    $statement = mysqli_prepare($db, 'DELETE FROM `tblUsers` WHERE `userUID` = ?');
+    mysqli_stmt_bind_param($statement, 'i', $userUID);
+    mysqli_stmt_execute($statement);
+    mysqli_stmt_close($statement);
+}
+
+/**
+ * Insert a tblDataDeletionRequests export-type row with a caller-controlled
+ * exportFilePath and exportExpiresAt (expressed as "hours from now", negative
+ * for already-expired). Returns the requestUID.
+ *
+ * @param  mysqli $db
+ * @param  int    $userUID
+ * @param  string $exportFilePath
+ * @param  int    $expiresInHours
+ * @return int
+ */
+function g2ml_cronret_test_insert_export_request(mysqli $db, int $userUID, string $exportFilePath, int $expiresInHours): int
+{
+    $exportExpiresAt = gmdate('Y-m-d H:i:s', time() + ($expiresInHours * 3600));
+
+    $statement = mysqli_prepare(
+        $db,
+        'INSERT INTO `tblDataDeletionRequests` (`userUID`, `requestType`, `status`, `exportFilePath`, `exportExpiresAt`) '
+        . 'VALUES (?, \'export\', \'completed\', ?, ?)'
+    );
+
+    mysqli_stmt_bind_param($statement, 'iss', $userUID, $exportFilePath, $exportExpiresAt);
+    $ok = mysqli_stmt_execute($statement);
+
+    if ($ok === false)
+    {
+        $error = mysqli_stmt_error($statement);
+        mysqli_stmt_close($statement);
+        throw new RuntimeException('Insert (export request) failed: ' . $error);
+    }
+
+    $requestUID = (int) mysqli_stmt_insert_id($statement);
+    mysqli_stmt_close($statement);
+
+    return $requestUID;
+}
+
+/**
+ * Read back a tblDataDeletionRequests row's exportFilePath by requestUID.
+ *
+ * @param  mysqli $db
+ * @param  int    $requestUID
+ * @return array<string, mixed>|null
+ */
+function g2ml_cronret_test_fetch_export_request(mysqli $db, int $requestUID): ?array
+{
+    $statement = mysqli_prepare(
+        $db,
+        'SELECT `exportFilePath` FROM `tblDataDeletionRequests` WHERE `requestUID` = ? LIMIT 1'
+    );
+    mysqli_stmt_bind_param($statement, 'i', $requestUID);
+    mysqli_stmt_execute($statement);
+    $result = mysqli_stmt_get_result($statement);
+    $row    = mysqli_fetch_assoc($result);
+    mysqli_free_result($result);
+    mysqli_stmt_close($statement);
+
+    if ($row === null)
+    {
+        return null;
+    }
+
+    return $row;
+}
+
+/**
+ * Insert an expired (or active) tblUserSessions row for a userUID.
+ *
+ * @param  mysqli $db
+ * @param  int    $userUID
+ * @param  string $marker
+ * @param  int    $expiresInPastSeconds  Positive = already expired.
+ * @return int
+ */
+function g2ml_cronret_test_insert_session(mysqli $db, int $userUID, string $marker, int $expiresInPastSeconds): int
+{
+    $sessionToken = hash('sha256', $marker);
+    $ipAddress    = '203.0.113.167';
+    $expiresAt    = gmdate('Y-m-d H:i:s', time() - $expiresInPastSeconds);
+
+    $statement = mysqli_prepare(
+        $db,
+        'INSERT INTO `tblUserSessions` (`userUID`, `sessionToken`, `ipAddress`, `expiresAt`, `isActive`) '
+        . 'VALUES (?, ?, ?, ?, 1)'
+    );
+
+    mysqli_stmt_bind_param($statement, 'isss', $userUID, $sessionToken, $ipAddress, $expiresAt);
+    $ok = mysqli_stmt_execute($statement);
+
+    if ($ok === false)
+    {
+        $error = mysqli_stmt_error($statement);
+        mysqli_stmt_close($statement);
+        throw new RuntimeException('Insert (session) failed: ' . $error);
+    }
+
+    $sessionUID = (int) mysqli_stmt_insert_id($statement);
+    mysqli_stmt_close($statement);
+
+    return $sessionUID;
+}
+
+/**
+ * Count tblUserSessions rows for a given sessionUID.
+ *
+ * @param  mysqli $db
+ * @param  int    $sessionUID
+ * @return int
+ */
+function g2ml_cronret_test_count_session(mysqli $db, int $sessionUID): int
+{
+    $statement = mysqli_prepare($db, 'SELECT COUNT(*) AS cnt FROM `tblUserSessions` WHERE `sessionUID` = ?');
+    mysqli_stmt_bind_param($statement, 'i', $sessionUID);
+    mysqli_stmt_execute($statement);
+    $result = mysqli_stmt_get_result($statement);
+    $row    = mysqli_fetch_assoc($result);
+    mysqli_free_result($result);
+    mysqli_stmt_close($statement);
+
+    return (int) $row['cnt'];
+}
+
+// ----------------------------------------------------------------------------
+// Ensure the [default] org + free tier exist (FK targets for tblUsers).
+// ----------------------------------------------------------------------------
+$g2mlCronRetSetupResult = mysqli_query(
+    $db,
+    "INSERT INTO `tblSubscriptionTiers` (`tierID`, `tierName`) "
+    . "VALUES ('free', 'Free') "
+    . "ON DUPLICATE KEY UPDATE `tierName` = VALUES(`tierName`)"
+);
+
+if ($g2mlCronRetSetupResult === false)
+{
+    throw new RuntimeException('Setup query failed (tblSubscriptionTiers): ' . mysqli_error($db));
+}
+
+$g2mlCronRetSetupResult = mysqli_query(
+    $db,
+    "INSERT INTO `tblOrganisations` (`orgHandle`, `orgName`, `orgFallbackURL`, `tierID`, `isActive`) "
+    . "VALUES ('[default]', 'Default Test Org', 'https://go2my.link/fallback', 'free', 1) "
+    . "ON DUPLICATE KEY UPDATE `orgFallbackURL` = VALUES(`orgFallbackURL`)"
+);
+
+if ($g2mlCronRetSetupResult === false)
+{
+    throw new RuntimeException('Setup query failed (tblOrganisations): ' . mysqli_error($db));
+}
+
+// ============================================================================
+// (1) Master gate — a total no-op when off.
+// ============================================================================
+test('cron retention (#167): master gate off — report {enabled:false}, rows untouched', function () use ($db): void
+{
+    $marker  = 'cronret167_gate_' . substr(hash('sha256', (string) microtime(true)), 0, 12);
+    $userUID = g2ml_cronret_test_insert_user($db, $marker);
+    $logUID  = g2ml_cronret_test_insert_activity($db, $userUID, 200, '198.51.100.10', 'TestAgent/1.0');
+
+    setSetting('retention.enforcement_enabled', false, 'System');
+
+    $report = g2ml_cronRunRetentionJob(30, 500);
+
+    assert_same(false, $report['enabled'], 'A disabled retention job reports enabled:false');
+
+    $row = g2ml_cronret_test_fetch_activity($db, $logUID);
+    assert_same('198.51.100.10', $row['ipAddress'], 'ipAddress untouched while the master gate is off');
+
+    g2ml_cronret_test_cleanup_activity($db, $userUID);
+    g2ml_cronret_test_cleanup_user($db, $userUID);
+});
+
+// ============================================================================
+// (2) Anonymise sweep — old row anonymised, recent row untouched, idempotent.
+// ============================================================================
+test('cron retention (#167): anonymise sweep treats old rows, leaves recent rows alone, and converges on re-run', function () use ($db): void
+{
+    $marker    = 'cronret167_anon_' . substr(hash('sha256', (string) microtime(true)), 0, 12);
+    $userUID   = g2ml_cronret_test_insert_user($db, $marker);
+    $oldLogUID = g2ml_cronret_test_insert_activity($db, $userUID, 91, '198.51.100.20', 'OldAgent/1.0');
+    $newLogUID = g2ml_cronret_test_insert_activity($db, $userUID, 89, '198.51.100.21', 'NewAgent/1.0');
+
+    setSetting('retention.enforcement_enabled', true, 'System');
+    setSetting('retention.activity_log_anonymise_days', 90, 'System');
+    setSetting('retention.activity_log_purge_days', 0, 'System');
+    setSetting('retention.batch_size', 500, 'System');
+
+    $firstReport = g2ml_cronRunRetentionJob(30, 500);
+
+    assert_true($firstReport['anonymise']['swept'] >= 1, 'At least the one old row was swept');
+
+    $oldRow = g2ml_cronret_test_fetch_activity($db, $oldLogUID);
+    assert_same('0.0.0.0', $oldRow['ipAddress'], 'The 91-day-old row is anonymised');
+    assert_same(null, $oldRow['requestUserAgent'], 'The 91-day-old row loses its user agent');
+
+    $newRow = g2ml_cronret_test_fetch_activity($db, $newLogUID);
+    assert_same('198.51.100.21', $newRow['ipAddress'], 'The 89-day-old row is left completely alone');
+    assert_same('NewAgent/1.0', $newRow['requestUserAgent'], 'The 89-day-old row keeps its user agent');
+
+    $secondReport = g2ml_cronRunRetentionJob(30, 500);
+    assert_same(0, $secondReport['anonymise']['swept'], 'A re-run sweeps nothing further — idempotent');
+
+    g2ml_cronret_test_cleanup_activity($db, $userUID);
+    g2ml_cronret_test_cleanup_user($db, $userUID);
+});
+
+// ============================================================================
+// (3) Batching — a small batch size loops across multiple chunks and
+//     terminates having swept every eligible row.
+// ============================================================================
+test('cron retention (#167): the anonymise sweep loops across small batches and terminates', function () use ($db): void
+{
+    $marker   = 'cronret167_batch_' . substr(hash('sha256', (string) microtime(true)), 0, 12);
+    $userUID  = g2ml_cronret_test_insert_user($db, $marker);
+    $logUIDs  = [];
+
+    for ($index = 0; $index < 3; $index++)
+    {
+        $logUIDs[] = g2ml_cronret_test_insert_activity($db, $userUID, 95, '198.51.100.3' . $index, 'BatchAgent/1.0');
+    }
+
+    $deadline = microtime(true) + 30;
+    $report   = g2ml_retentionAnonymiseActivityLog(90, 1, $deadline);
+
+    assert_same(3, $report['swept'], 'All three eligible rows were swept across multiple 1-row batches');
+    assert_true($report['batches'] >= 3, 'The loop actually iterated multiple times (batch size 1, 3 rows)');
+    assert_same(false, $report['partial'], 'The loop terminated on its own, not on the time budget');
+
+    foreach ($logUIDs as $logUID)
+    {
+        $row = g2ml_cronret_test_fetch_activity($db, $logUID);
+        assert_same('0.0.0.0', $row['ipAddress'], 'Every row in the batch was anonymised');
+    }
+
+    g2ml_cronret_test_cleanup_activity($db, $userUID);
+    g2ml_cronret_test_cleanup_user($db, $userUID);
+});
+
+// ============================================================================
+// (4) Purge default-off — rows remain (anonymised only), never deleted.
+// ============================================================================
+test('cron retention (#167): the purge sweep stays off by default — rows remain', function () use ($db): void
+{
+    $marker  = 'cronret167_purgeoff_' . substr(hash('sha256', (string) microtime(true)), 0, 12);
+    $userUID = g2ml_cronret_test_insert_user($db, $marker);
+    $logUID  = g2ml_cronret_test_insert_activity($db, $userUID, 200, '198.51.100.40', 'PurgeOffAgent/1.0');
+
+    setSetting('retention.enforcement_enabled', true, 'System');
+    setSetting('retention.activity_log_anonymise_days', 90, 'System');
+    setSetting('retention.activity_log_purge_days', 0, 'System');
+    setSetting('retention.batch_size', 500, 'System');
+
+    $report = g2ml_cronRunRetentionJob(30, 500);
+
+    assert_same('disabled', $report['purge']['skipped'], 'The purge sweep reports itself skipped:disabled');
+
+    $row = g2ml_cronret_test_fetch_activity($db, $logUID);
+    assert_true($row !== null, 'The 200-day-old row still exists — only anonymised, never purged');
+    assert_same('0.0.0.0', $row['ipAddress'], 'The row was anonymised by the (still-active) anonymise sweep');
+
+    g2ml_cronret_test_cleanup_activity($db, $userUID);
+    g2ml_cronret_test_cleanup_user($db, $userUID);
+});
+
+// ============================================================================
+// (5) Purge misconfiguration — a purge window narrower than the anonymise
+//     window is refused rather than destroying not-yet-anonymised rows.
+// ============================================================================
+test('cron retention (#167): a misconfigured purge window (< anonymise window) is skipped', function () use ($db): void
+{
+    $marker  = 'cronret167_misconfig_' . substr(hash('sha256', (string) microtime(true)), 0, 12);
+    $userUID = g2ml_cronret_test_insert_user($db, $marker);
+    $logUID  = g2ml_cronret_test_insert_activity($db, $userUID, 200, '198.51.100.50', 'MisconfigAgent/1.0');
+
+    setSetting('retention.enforcement_enabled', true, 'System');
+    setSetting('retention.activity_log_anonymise_days', 90, 'System');
+    setSetting('retention.activity_log_purge_days', 30, 'System');
+    setSetting('retention.batch_size', 500, 'System');
+
+    $report = g2ml_cronRunRetentionJob(30, 500);
+
+    assert_same('misconfigured', $report['purge']['skipped'], 'purge_days (30) < anonymise_days (90) must be refused');
+
+    $row = g2ml_cronret_test_fetch_activity($db, $logUID);
+    assert_true($row !== null, 'The row was not deleted by the refused purge');
+
+    g2ml_cronret_test_cleanup_activity($db, $userUID);
+    g2ml_cronret_test_cleanup_user($db, $userUID);
+
+    // Reset to a safe default for any later test in this process.
+    setSetting('retention.activity_log_purge_days', 0, 'System');
+});
+
+// ============================================================================
+// (6) Expired export sweep — confined file unlinked + path NULLed; unexpired
+//     row + file left completely alone.
+// ============================================================================
+test('cron retention (#167): expired export sweep unlinks a confined file and NULLs the path; unexpired pair untouched', function () use ($db): void
+{
+    $marker  = 'cronret167_export_' . substr(hash('sha256', (string) microtime(true)), 0, 12);
+    $userUID = g2ml_cronret_test_insert_user($db, $marker);
+
+    $exportsDir = G2ML_UPLOADS . DIRECTORY_SEPARATOR . 'exports';
+
+    $expiredFilePath = $exportsDir . DIRECTORY_SEPARATOR . 'export_' . $marker . '_expired.json';
+    file_put_contents($expiredFilePath, '{"marker":"' . $marker . '"}');
+    $expiredRequestUID = g2ml_cronret_test_insert_export_request($db, $userUID, $expiredFilePath, -1);
+
+    $activeFilePath = $exportsDir . DIRECTORY_SEPARATOR . 'export_' . $marker . '_active.json';
+    file_put_contents($activeFilePath, '{"marker":"' . $marker . '"}');
+    $activeRequestUID = g2ml_cronret_test_insert_export_request($db, $userUID, $activeFilePath, 48);
+
+    $deadline = microtime(true) + 30;
+    $report   = g2ml_retentionPurgeExpiredExports($deadline);
+
+    assert_true($report['swept'] >= 1, 'At least the one expired export row was swept');
+
+    assert_false(is_file($expiredFilePath), 'The expired, confined file was unlinked');
+    $expiredRow = g2ml_cronret_test_fetch_export_request($db, $expiredRequestUID);
+    assert_true($expiredRow !== null, 'The expired request ROW itself remains (audit trail)');
+    assert_same(null, $expiredRow['exportFilePath'], 'exportFilePath is NULLed on the expired row');
+
+    assert_true(is_file($activeFilePath), 'The unexpired file is left completely alone');
+    $activeRow = g2ml_cronret_test_fetch_export_request($db, $activeRequestUID);
+    assert_same($activeFilePath, $activeRow['exportFilePath'], 'The unexpired row keeps its exportFilePath');
+
+    if (is_file($activeFilePath))
+    {
+        unlink($activeFilePath);
+    }
+
+    $cleanupStatement = mysqli_prepare($db, 'DELETE FROM `tblDataDeletionRequests` WHERE `userUID` = ?');
+    mysqli_stmt_bind_param($cleanupStatement, 'i', $userUID);
+    mysqli_stmt_execute($cleanupStatement);
+    mysqli_stmt_close($cleanupStatement);
+
+    g2ml_cronret_test_cleanup_user($db, $userUID);
+});
+
+// ============================================================================
+// (7) Path confinement — a tampered/escaping exportFilePath is NEVER
+//     unlinked, but the DB path is still NULLed.
+// ============================================================================
+test('cron retention (#167): a path escaping the exports directory is never unlinked, only NULLed', function () use ($db): void
+{
+    $marker  = 'cronret167_escape_' . substr(hash('sha256', (string) microtime(true)), 0, 12);
+    $userUID = g2ml_cronret_test_insert_user($db, $marker);
+
+    $evilFilePath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'g2ml_it_evil_' . $marker . '.json';
+    file_put_contents($evilFilePath, '{"marker":"' . $marker . '"}');
+
+    $requestUID = g2ml_cronret_test_insert_export_request($db, $userUID, $evilFilePath, -1);
+
+    $deadline = microtime(true) + 30;
+    g2ml_retentionPurgeExpiredExports($deadline);
+
+    assert_true(is_file($evilFilePath), 'A path outside the exports directory is NEVER unlinked');
+
+    $row = g2ml_cronret_test_fetch_export_request($db, $requestUID);
+    assert_same(null, $row['exportFilePath'], 'The DB path is still NULLed even though the file was left alone');
+
+    unlink($evilFilePath);
+
+    $cleanupStatement = mysqli_prepare($db, 'DELETE FROM `tblDataDeletionRequests` WHERE `userUID` = ?');
+    mysqli_stmt_bind_param($cleanupStatement, 'i', $userUID);
+    mysqli_stmt_execute($cleanupStatement);
+    mysqli_stmt_close($cleanupStatement);
+
+    g2ml_cronret_test_cleanup_user($db, $userUID);
+});
+
+// ============================================================================
+// (8) Sessions — an expired session row is removed and counted.
+// ============================================================================
+test('cron retention (#167): the session sweep removes an expired session', function () use ($db): void
+{
+    $marker     = 'cronret167_session_' . substr(hash('sha256', (string) microtime(true)), 0, 12);
+    $userUID    = g2ml_cronret_test_insert_user($db, $marker);
+    $sessionUID = g2ml_cronret_test_insert_session($db, $userUID, $marker, 3600);
+
+    assert_same(1, g2ml_cronret_test_count_session($db, $sessionUID), 'The expired session row exists before the sweep');
+
+    $report = g2ml_retentionCleanSessions();
+
+    assert_true($report['swept'] >= 1, 'At least the one expired session was swept');
+    assert_same(0, g2ml_cronret_test_count_session($db, $sessionUID), 'The expired session row is gone');
+
+    g2ml_cronret_test_cleanup_user($db, $userUID);
+});
+
+// ============================================================================
+// (9) Advisory lock — a concurrent holder on a SECOND connection genuinely
+//     blocks g2ml_cronAcquireLock(), and release makes it available again.
+// ============================================================================
+test('cron retention (#167): the advisory lock blocks a concurrent acquire and releases cleanly', function (): void
+{
+    $secondConnection = @mysqli_init();
+
+    if ($secondConnection === false)
+    {
+        throw new RuntimeException('Could not initialise a second mysqli connection for the lock test');
+    }
+
+    $opened = @mysqli_real_connect($secondConnection, DB_HOST, DB_USER, DB_PASS, DB_NAME, DB_PORT);
+
+    if ($opened === false)
+    {
+        throw new RuntimeException('Could not open a second connection for the lock test: ' . mysqli_connect_error());
+    }
+
+    $lockResult = mysqli_query($secondConnection, "SELECT GET_LOCK(CONCAT(DATABASE(), ':g2ml_cron'), 5) AS lockResult");
+    $lockRow    = mysqli_fetch_assoc($lockResult);
+
+    assert_same(1, (int) $lockRow['lockResult'], 'The second connection must acquire the lock first');
+
+    assert_false(g2ml_cronAcquireLock(), 'The application connection must NOT be able to acquire an already-held lock');
+
+    mysqli_query($secondConnection, "SELECT RELEASE_LOCK(CONCAT(DATABASE(), ':g2ml_cron'))");
+    mysqli_close($secondConnection);
+
+    assert_true(g2ml_cronAcquireLock(), 'Once released, the application connection can acquire the lock');
+
+    g2ml_cronReleaseLock();
+});

--- a/tests/unit/cron_dispatch_test.php
+++ b/tests/unit/cron_dispatch_test.php
@@ -1,0 +1,313 @@
+<?php
+/**
+ * Copyright (c) 2024–2026 MWBM Partners Ltd (MWservices).
+ * All rights reserved.
+ *
+ * This source code is proprietary and confidential.
+ * Unauthorised copying, modification, or distribution is strictly prohibited.
+ */
+
+/**
+ * ============================================================================
+ * 🧪 Unit tests — Scheduled Jobs pure helpers (cron.php) (#163, #167)
+ * ============================================================================
+ *
+ * Covers every PURE helper in web/_functions/cron.php — no database, no
+ * settings layer, no superglobals beyond what is passed explicitly as a
+ * parameter. These are the exact functions the dispatch endpoint and the
+ * probabilistic page_init.php fallback both build on, so pinning their
+ * behaviour here is what proves (independently of any live DB run):
+ *
+ *   - the token check is constant-time, fails closed on a null/empty/weak
+ *     stored token, and matches only on an exact, well-formed byte match;
+ *   - job-name parsing rejects anything outside the exact allow-list;
+ *   - the deletion executor's mode resolution NEVER unlocks "live" on
+ *     anything other than the exact boolean false for the dry-run flag;
+ *   - every clamp helper fails safe on non-numeric/out-of-range input; and
+ *   - the export-path confinement guard rejects both a directory-traversal
+ *     escape AND a sibling-directory string-prefix collision.
+ *
+ * @package    Go2My.Link
+ * @subpackage Tests
+ * @since      v1.7.0 — GDPR Scheduled Jobs (#163, #167)
+ * ============================================================================
+ */
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__, 1) . '/../web/_functions/cron.php';
+
+// ============================================================================
+// 🔑 g2ml_cronVerifyToken()
+// ============================================================================
+
+test('cron token: null provided token fails', function (): void
+{
+    assert_false(g2ml_cronVerifyToken(null, str_repeat('a', 64)), 'A null provided token must never match');
+});
+
+test('cron token: empty provided token fails', function (): void
+{
+    assert_false(g2ml_cronVerifyToken('', str_repeat('a', 64)), 'An empty provided token must never match');
+});
+
+test('cron token: null stored token fails (endpoint-inert-when-unseeded)', function (): void
+{
+    assert_false(g2ml_cronVerifyToken(str_repeat('a', 64), null), 'A null stored token (the seeded default) must never authenticate anyone');
+});
+
+test('cron token: empty stored token fails', function (): void
+{
+    assert_false(g2ml_cronVerifyToken(str_repeat('a', 64), ''), 'An empty stored token must never authenticate anyone');
+});
+
+test('cron token: a stored token shorter than 32 chars fails even on an identical match', function (): void
+{
+    $weakToken = str_repeat('a', 31);
+
+    assert_false(g2ml_cronVerifyToken($weakToken, $weakToken), 'A weak (<32 char) stored token must fail closed, not "work"');
+});
+
+test('cron token: a 64-char exact match succeeds', function (): void
+{
+    $token = bin2hex(random_bytes(32));
+
+    assert_true(g2ml_cronVerifyToken($token, $token), 'An identical 64-char token must verify');
+});
+
+test('cron token: a 64-char mismatch (one differing character) fails', function (): void
+{
+    $stored   = str_repeat('a', 64);
+    $provided = str_repeat('a', 63) . 'b';
+
+    assert_false(g2ml_cronVerifyToken($provided, $stored), 'A single differing character must fail verification');
+});
+
+test('cron token: a differing-length mismatch fails', function (): void
+{
+    $stored   = str_repeat('a', 64);
+    $provided = str_repeat('a', 40);
+
+    assert_false(g2ml_cronVerifyToken($provided, $stored), 'A shorter provided token must fail verification');
+});
+
+// ============================================================================
+// 🔑 g2ml_cronReadPresentedToken()
+// ============================================================================
+
+test('cron token read: the header takes priority over the query parameter', function (): void
+{
+    $server = ['HTTP_X_G2ML_CRON_TOKEN' => 'from-header'];
+    $get    = ['token' => 'from-query'];
+
+    assert_same('from-header', g2ml_cronReadPresentedToken($server, $get), 'Header must win when both are present');
+});
+
+test('cron token read: falls back to ?token= when the header is absent', function (): void
+{
+    $server = [];
+    $get    = ['token' => 'from-query'];
+
+    assert_same('from-query', g2ml_cronReadPresentedToken($server, $get), 'The query parameter must be used when there is no header');
+});
+
+test('cron token read: returns null when neither the header nor the query parameter is present', function (): void
+{
+    assert_same(null, g2ml_cronReadPresentedToken([], []), 'No token anywhere must resolve to null');
+});
+
+test('cron token read: an empty header value falls back to the query parameter', function (): void
+{
+    $server = ['HTTP_X_G2ML_CRON_TOKEN' => ''];
+    $get    = ['token' => 'from-query'];
+
+    assert_same('from-query', g2ml_cronReadPresentedToken($server, $get), 'An empty header value must not shadow a real query token');
+});
+
+// ============================================================================
+// 🧭 g2ml_cronNormaliseJobName()
+// ============================================================================
+
+test('job name: null normalises to "all"', function (): void
+{
+    assert_same('all', g2ml_cronNormaliseJobName(null), 'An absent ?job= must mean "run everything"');
+});
+
+test('job name: an empty string normalises to "all"', function (): void
+{
+    assert_same('all', g2ml_cronNormaliseJobName(''), 'An empty ?job= must mean "run everything"');
+});
+
+test('job name: "deletion" passes through unchanged', function (): void
+{
+    assert_same('deletion', g2ml_cronNormaliseJobName('deletion'));
+});
+
+test('job name: "retention" passes through unchanged', function (): void
+{
+    assert_same('retention', g2ml_cronNormaliseJobName('retention'));
+});
+
+test('job name: "all" passes through unchanged', function (): void
+{
+    assert_same('all', g2ml_cronNormaliseJobName('all'));
+});
+
+test('job name: "ALL" (wrong case) is rejected, not silently folded', function (): void
+{
+    assert_same(null, g2ml_cronNormaliseJobName('ALL'), 'Job names are lower-case only — no case folding');
+});
+
+test('job name: an unrecognised string is rejected', function (): void
+{
+    assert_same(null, g2ml_cronNormaliseJobName('foo'));
+});
+
+test('job name: a non-string value (array) is rejected', function (): void
+{
+    assert_same(null, g2ml_cronNormaliseJobName(['deletion']));
+});
+
+// ============================================================================
+// 📅 g2ml_cronEffectiveGraceDays()
+// ============================================================================
+
+test('grace days: a valid numeric string passes through', function (): void
+{
+    assert_same(30, g2ml_cronEffectiveGraceDays('30'));
+});
+
+test('grace days: zero falls back to 30 (never shrinks the grace window to 0)', function (): void
+{
+    assert_same(30, g2ml_cronEffectiveGraceDays(0));
+});
+
+test('grace days: a negative value falls back to 30', function (): void
+{
+    assert_same(30, g2ml_cronEffectiveGraceDays(-5));
+});
+
+test('grace days: a non-numeric value falls back to 30', function (): void
+{
+    assert_same(30, g2ml_cronEffectiveGraceDays('abc'));
+});
+
+test('grace days: a value above the sane 365-day ceiling falls back to 30', function (): void
+{
+    assert_same(30, g2ml_cronEffectiveGraceDays(400));
+});
+
+test('grace days: a valid in-range value passes through unchanged', function (): void
+{
+    assert_same(7, g2ml_cronEffectiveGraceDays(7));
+});
+
+// ============================================================================
+// 🚦 g2ml_cronDeletionMode()
+// ============================================================================
+
+test('deletion mode: enabled=false is always "disabled", regardless of dry-run', function (): void
+{
+    assert_same('disabled', g2ml_cronDeletionMode(false, false));
+    assert_same('disabled', g2ml_cronDeletionMode(false, true));
+    assert_same('disabled', g2ml_cronDeletionMode(false, null));
+});
+
+test('deletion mode: enabled=true, dryRun=true is "dry-run"', function (): void
+{
+    assert_same('dry-run', g2ml_cronDeletionMode(true, true));
+});
+
+test('deletion mode: enabled=true, dryRun=null is "dry-run" (fail-safe)', function (): void
+{
+    assert_same('dry-run', g2ml_cronDeletionMode(true, null));
+});
+
+test('deletion mode: enabled=true, dryRun="0" (string) is still "dry-run" (only exact boolean false unlocks live)', function (): void
+{
+    assert_same('dry-run', g2ml_cronDeletionMode(true, '0'));
+});
+
+test('deletion mode: enabled=true, dryRun=false (exact boolean) is "live"', function (): void
+{
+    assert_same('live', g2ml_cronDeletionMode(true, false));
+});
+
+test('deletion mode: enabled="1" (string, not exact boolean true) is "disabled" (fail-safe)', function (): void
+{
+    assert_same('disabled', g2ml_cronDeletionMode('1', false));
+});
+
+// ============================================================================
+// 🧮 g2ml_cronClampInt()
+// ============================================================================
+
+test('clamp int: an in-range value passes through unchanged', function (): void
+{
+    assert_same(10, g2ml_cronClampInt(10, 1, 100, 10));
+});
+
+test('clamp int: a value below the minimum clamps up to the minimum', function (): void
+{
+    assert_same(1, g2ml_cronClampInt(-5, 1, 100, 10));
+});
+
+test('clamp int: a value above the maximum clamps down to the maximum', function (): void
+{
+    assert_same(100, g2ml_cronClampInt(500, 1, 100, 10));
+});
+
+test('clamp int: a non-numeric value falls back to the fallback', function (): void
+{
+    assert_same(10, g2ml_cronClampInt('abc', 1, 100, 10));
+});
+
+test('clamp int: the retention batch size range clamps correctly (50-2000)', function (): void
+{
+    assert_same(50, g2ml_cronClampInt(1, 50, 2000, 500));
+    assert_same(2000, g2ml_cronClampInt(999999, 50, 2000, 500));
+});
+
+test('clamp int: divisor of 0 clamps to 0 (the "fallback path disabled" sentinel)', function (): void
+{
+    assert_same(0, g2ml_cronClampInt(0, 0, PHP_INT_MAX, 500));
+});
+
+test('clamp int: a negative divisor also clamps to 0', function (): void
+{
+    assert_same(0, g2ml_cronClampInt(-3, 0, PHP_INT_MAX, 500));
+});
+
+test('clamp int: a non-numeric divisor falls back to the default (not 0)', function (): void
+{
+    assert_same(500, g2ml_cronClampInt(null, 0, PHP_INT_MAX, 500));
+});
+
+// ============================================================================
+// 📁 g2ml_retentionPathIsConfined()
+// ============================================================================
+
+test('path confinement: a file directly inside the base directory is confined', function (): void
+{
+    assert_true(g2ml_retentionPathIsConfined('/var/app/exports', '/var/app/exports/export_1.json'));
+});
+
+test('path confinement: a directory-traversal escape is rejected', function (): void
+{
+    assert_false(g2ml_retentionPathIsConfined('/var/app/exports', '/var/app/secrets/export_1.json'));
+});
+
+test('path confinement: a sibling directory sharing a string prefix is rejected (trailing-separator trap)', function (): void
+{
+    assert_false(g2ml_retentionPathIsConfined('/var/app/exports', '/var/app/exports_evil/export_1.json'));
+});
+
+test('path confinement: an empty base directory is never confined', function (): void
+{
+    assert_false(g2ml_retentionPathIsConfined('', '/var/app/exports/export_1.json'));
+});
+
+test('path confinement: an empty file path is never confined', function (): void
+{
+    assert_false(g2ml_retentionPathIsConfined('/var/app/exports', ''));
+});

--- a/web/Go2My.Link/_admin/public_html/cron.php
+++ b/web/Go2My.Link/_admin/public_html/cron.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * Copyright (c) 2024–2026 MWBM Partners Ltd (MWservices).
+ * All rights reserved.
+ *
+ * This source code is proprietary and confidential.
+ * Unauthorised copying, modification, or distribution is strictly prohibited.
+ */
+
+/**
+ * ============================================================================
+ * ⏰ Go2My.Link — Scheduled Jobs Dispatch Endpoint (Admin Dashboard) (#163, #167)
+ * ============================================================================
+ *
+ * A token-guarded standalone endpoint any external scheduler can hit —
+ * Dreamhost Panel cron `curl`, cron-job.org, GitHub Actions `schedule:` (see
+ * HANDOFF.md #178 for the scheduler decision). Reachable at
+ * https://admin.go2my.link/cron.php (+ the alpha subdomain equivalent).
+ *
+ * ----------------------------------------------------------------------------
+ * Why this is a standalone script, not a pages/* route
+ * ----------------------------------------------------------------------------
+ * Identical reasoning to analytics-export.php (#44) — this file is the
+ * template it was copied from. Every route the file-based router resolves is
+ * required AFTER header.php has ALREADY echoed HTML; a route file cannot
+ * therefore send its own JSON Content-Type/404/405 status codes. This file is
+ * instead a second, independent entry point in public_html/, served directly
+ * by the existing `.htaccess` clean-URL rule (RewriteCond
+ * %{REQUEST_FILENAME} !-f) — because cron.php IS a real file, that rule never
+ * routes it through index.php at all.
+ *
+ * ----------------------------------------------------------------------------
+ * Safety model — every failure path is a byte-identical generic 404
+ * ----------------------------------------------------------------------------
+ * cron.enabled defaults OFF and cron.dispatch_token defaults to NULL (see
+ * web/_sql/seeds/020_cron_gdpr_settings.sql) — a fresh install's endpoint
+ * answers 404 to every request, indistinguishable from a file that does not
+ * exist. Feature-off is NOT logged (not an attack); a wrong/missing token
+ * WITH the feature on IS logged (cron_dispatch_denied) before the same 404.
+ * No rate limiting is added deliberately — a 256-bit token is not
+ * brute-forceable, and a failure sleep() would tie up an Apache/FastCGI
+ * worker (a self-inflicted DoS lever on shared hosting).
+ *
+ * The #163 deletion executor only ever runs from THIS endpoint — never from
+ * the probabilistic page_init.php fallback (retention-only) — because
+ * irreversible work must never ride an anonymous visitor's request.
+ * G2ML_CRON_DISPATCH is defined BEFORE page_init.php runs specifically so
+ * that fallback hook can detect an endpoint run already in progress and skip
+ * itself (no self-race for the advisory lock).
+ *
+ * ----------------------------------------------------------------------------
+ * Parameters
+ * ----------------------------------------------------------------------------
+ *   Header X-G2ML-Cron-Token   Preferred token transport.
+ *   ?token=                    Fallback transport for header-less schedulers.
+ *                              NOTE: this form lands in Apache access logs —
+ *                              the header is strongly recommended instead.
+ *   ?job=                      Optional. One of 'deletion' | 'retention' |
+ *                              'all' (default). Anything else is a 400 —
+ *                              evaluated ONLY after authentication succeeds,
+ *                              so an invalid job name can never be used to
+ *                              probe for the endpoint's existence.
+ *
+ * @package    Go2My.Link
+ * @subpackage ComponentA_Admin
+ * @version    1.0.0
+ * @since      v1.7.0 — GDPR Scheduled Jobs (#163, #167)
+ *
+ * 📖 References:
+ *     - Job library:                web/_functions/cron.php
+ *     - Existing #163 executor:     web/_functions/data_rights.php
+ *     - Standalone-entry precedent: web/Go2My.Link/_admin/public_html/analytics-export.php
+ *     - Settings seed (all OFF):    web/_sql/seeds/020_cron_gdpr_settings.sql
+ * ============================================================================
+ */
+
+// ============================================================================
+// 🚩 Step 0: Mark this request as the dispatch entry point BEFORE
+// page_init.php runs, so the probabilistic retention hook there skips itself
+// and cannot race this request for the advisory lock.
+// ============================================================================
+
+define('G2ML_CRON_DISPATCH', true);
+
+// ============================================================================
+// 📦 Step 1: Load Component Auth Credentials (mirrors analytics-export.php)
+// ============================================================================
+
+$componentAuthPath = dirname(__DIR__, 2)
+    . DIRECTORY_SEPARATOR . '.auth'
+    . DIRECTORY_SEPARATOR . 'auth_creds.php';
+
+if (file_exists($componentAuthPath))
+{
+    require_once $componentAuthPath;
+}
+else
+{
+    error_log('[Go2My.Link] CRITICAL: Component A auth_creds.php not found at: ' . $componentAuthPath);
+}
+
+// ============================================================================
+// 🏷️ Step 2: Define Component Constants (mirrors analytics-export.php)
+// ============================================================================
+
+define('G2ML_COMPONENT',        'Admin');
+define('G2ML_COMPONENT_NAME',   'Admin Dashboard');
+define('G2ML_COMPONENT_DOMAIN', 'admin.go2my.link');
+define('G2ML_ROOT', dirname(__DIR__, 3));
+
+// ============================================================================
+// 🚀 Step 3: Bootstrap the Application (loads _functions/*.php incl.
+// cron.php, and the settings cache).
+// ============================================================================
+
+require_once G2ML_ROOT
+    . DIRECTORY_SEPARATOR . '_includes'
+    . DIRECTORY_SEPARATOR . 'page_init.php';
+
+// ============================================================================
+// 🔐 Step 4: Method Guard — GET and POST only.
+// ============================================================================
+
+$requestMethod = $_SERVER['REQUEST_METHOD'] ?? '';
+
+if ($requestMethod !== 'GET' && $requestMethod !== 'POST')
+{
+    http_response_code(405);
+    header('Content-Type: text/plain; charset=utf-8');
+    header('Allow: GET, POST');
+    echo 'Method Not Allowed';
+    exit;
+}
+
+// ============================================================================
+// 🔒 Step 5: Authorisation.
+//
+// EVERY failure path below converges on g2ml_cronEmitNotFound() — a
+// byte-identical generic 404 (no distinction between "feature off", "no
+// token configured", "no token presented", and "wrong token"). The endpoint
+// is deliberately indistinguishable from a file that does not exist.
+// ============================================================================
+
+$cronEnabled = getSetting('cron.enabled', false);
+
+if ($cronEnabled !== true)
+{
+    // Feature off is not an attack signal — no logging, straight to the 404.
+    g2ml_cronEmitNotFound();
+}
+
+$providedToken = g2ml_cronReadPresentedToken($_SERVER, $_GET);
+$storedToken   = getSetting('cron.dispatch_token', null);
+
+if (g2ml_cronVerifyToken($providedToken, $storedToken) !== true)
+{
+    // The feature IS on but auth failed — log the denial (no token material
+    // is ever logged), then the SAME 404.
+    logActivity('cron_dispatch_denied', 'denied', 404, [
+        'logData' => ['reason' => 'auth'],
+    ]);
+
+    g2ml_cronEmitNotFound();
+}
+
+// ============================================================================
+// 🧭 Step 6: Job selection — evaluated ONLY post-auth, so an invalid job name
+// can never be used as an existence oracle for the endpoint.
+// ============================================================================
+
+$rawJob  = $_GET['job'] ?? null;
+$jobName = g2ml_cronNormaliseJobName($rawJob);
+
+if ($jobName === null)
+{
+    http_response_code(400);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['status' => 'error', 'error' => 'invalid_job']);
+    exit;
+}
+
+// ============================================================================
+// 🔒 Step 7: Advisory lock — timeout 0, never queues. A concurrent run
+// (another scheduler firing early, or an overlapping fallback hook — though
+// G2ML_CRON_DISPATCH already prevents that specific race) short-circuits to
+// a deliberate 200 'skipped' so schedulers do not retry-storm.
+// ============================================================================
+
+if (g2ml_cronAcquireLock() !== true)
+{
+    http_response_code(200);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['status' => 'skipped', 'reason' => 'already_running']);
+    exit;
+}
+
+// ============================================================================
+// 🏃 Step 8: Run the requested job(s) and report. The lock is released in a
+// finally block regardless of outcome; connection close is the backstop.
+// ============================================================================
+
+try
+{
+    $maxRuntimeSeconds = g2ml_cronClampInt(getSetting('cron.max_runtime_seconds', 50), 1, 300, 50);
+    $report            = g2ml_cronRunJobs($jobName, $maxRuntimeSeconds);
+}
+finally
+{
+    g2ml_cronReleaseLock();
+}
+
+http_response_code(200);
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store');
+echo json_encode($report, JSON_PRETTY_PRINT);
+exit;

--- a/web/_functions/cron.php
+++ b/web/_functions/cron.php
@@ -1,0 +1,1122 @@
+<?php
+/**
+ * Copyright (c) 2024–2026 MWBM Partners Ltd (MWservices).
+ * All rights reserved.
+ *
+ * This source code is proprietary and confidential.
+ * Unauthorised copying, modification, or distribution is strictly prohibited.
+ */
+
+/**
+ * ============================================================================
+ * ⏰ Go2My.Link — Scheduled Jobs (GDPR Deletion + Retention) (#163, #167)
+ * ============================================================================
+ *
+ * Provider-agnostic scheduled-jobs library. Holds ALL job logic — pure helpers
+ * plus the DB sweeps themselves — for two callers:
+ *
+ *   (a) the token-guarded standalone endpoint
+ *       web/Go2My.Link/_admin/public_html/cron.php, hit by any external
+ *       scheduler (Dreamhost Panel cron, cron-job.org, GitHub Actions
+ *       `schedule:`);
+ *   (b) a probabilistic fallback hook called once per request from
+ *       _includes/page_init.php (mirrors the existing 1-in-100 session/API
+ *       log idioms — see session.php::cleanExpiredSessions() and
+ *       api_ratelimit.php's own probabilistic prune) that runs RETENTION ONLY.
+ *
+ * The #163 deletion executor is deliberately endpoint-only — irreversible
+ * work must never ride an anonymous visitor's request. Every entry function
+ * re-checks its own gate setting and returns a no-op report when its feature
+ * is off, so requiring this file has ZERO effect until an operator explicitly
+ * flips the relevant settings (see web/_sql/seeds/020_cron_gdpr_settings.sql
+ * — every one of them seeds OFF/safe).
+ *
+ * Concurrency across both callers is a single MySQL advisory lock
+ * (GET_LOCK/RELEASE_LOCK, timeout 0 — never blocks, always short-circuits to
+ * "skipped"), which is crash-safe (MySQL releases it automatically if the
+ * holding connection dies) and works unmodified on Dreamhost shared hosting.
+ *
+ * Dependencies: db_query.php (dbSelect/dbSelectOne/dbUpdate/dbDelete),
+ *               settings.php (getSetting), activity_logger.php (logActivity),
+ *               data_rights.php (g2ml_processDataDeletion — #163's existing,
+ *               untouched executor), session.php (cleanExpiredSessions).
+ *
+ * @package    Go2My.Link
+ * @subpackage Functions
+ * @author     MWBM Partners Ltd (MWservices)
+ * @version    1.0.0
+ * @since      v1.7.0 — GDPR Scheduled Jobs (#163, #167)
+ *
+ * 📖 References:
+ *     - GDPR Art 17 (erasure SLA):  https://gdpr-info.eu/art-17-gdpr/
+ *     - GDPR Recital 26 (anon.):    https://gdpr-info.eu/recitals/no-26/
+ *     - MySQL GET_LOCK:             https://dev.mysql.com/doc/refman/8.0/en/locking-functions.html
+ *     - Existing executor:          web/_functions/data_rights.php
+ *                                   (g2ml_processDataDeletion, g2ml_anonymiseUserData)
+ *     - Standalone-endpoint model:  web/Go2My.Link/_admin/public_html/analytics-export.php
+ * ============================================================================
+ */
+
+// ============================================================================
+// 🛡️ Direct Access Guard
+// ============================================================================
+if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') === basename(__FILE__))
+{
+    header('Location: https://go2my.link');
+    exit;
+}
+
+// ============================================================================
+// 🔑 Auth / Parsing Helpers (PURE unless noted)
+// ============================================================================
+
+/**
+ * Constant-time comparison of the presented cron token against the stored
+ * token.
+ *
+ * PURE — no DB, no settings lookups; every input is a parameter so this is
+ * fully unit-testable without a database.
+ *
+ * Refuses (returns false) on: a null/empty provided token; a null/empty
+ * stored token (the fail-safe that keeps the endpoint unreachable while
+ * cron.dispatch_token is unset — its seeded default); and a stored token
+ * shorter than 32 characters (a weak owner-set token must fail closed rather
+ * than "work").
+ *
+ * Both sides are hashed (SHA-256, raw binary) BEFORE hash_equals() so the
+ * comparison is constant-time end to end and never leaks the stored token's
+ * true length via timing.
+ *
+ * @param  string|null $providedToken  The token presented by the caller.
+ * @param  string|null $storedToken    The token from getSetting('cron.dispatch_token').
+ * @return bool                        True only on an exact, well-formed match.
+ *
+ * 📖 Reference: https://www.php.net/manual/en/function.hash-equals.php
+ */
+function g2ml_cronVerifyToken(?string $providedToken, ?string $storedToken): bool
+{
+    if (!is_string($providedToken) || $providedToken === '')
+    {
+        return false;
+    }
+
+    if (!is_string($storedToken) || $storedToken === '')
+    {
+        return false;
+    }
+
+    if (strlen($storedToken) < 32)
+    {
+        return false;
+    }
+
+    $providedDigest = hash('sha256', $providedToken, true);
+    $storedDigest   = hash('sha256', $storedToken, true);
+
+    return hash_equals($storedDigest, $providedDigest);
+}
+
+/**
+ * PURE — read the presented cron token from the request: the
+ * X-G2ML-Cron-Token header takes priority, falling back to ?token= for
+ * header-less schedulers, else null.
+ *
+ * @param  array $server  The $_SERVER superglobal (or an equivalent test array).
+ * @param  array $get     The $_GET superglobal (or an equivalent test array).
+ * @return string|null    The presented token, or null when neither is set.
+ */
+function g2ml_cronReadPresentedToken(array $server, array $get): ?string
+{
+    if (isset($server['HTTP_X_G2ML_CRON_TOKEN'])
+        && is_string($server['HTTP_X_G2ML_CRON_TOKEN'])
+        && $server['HTTP_X_G2ML_CRON_TOKEN'] !== '')
+    {
+        return $server['HTTP_X_G2ML_CRON_TOKEN'];
+    }
+
+    if (isset($get['token']) && is_string($get['token']) && $get['token'] !== '')
+    {
+        return $get['token'];
+    }
+
+    return null;
+}
+
+/**
+ * PURE — normalise the caller-supplied ?job= value to one of 'deletion',
+ * 'retention', or 'all'.
+ *
+ * An absent value (null) or an empty string both mean "run everything" and
+ * normalise to 'all'. Any value that is not a string, or a string that is not
+ * exactly one of the three accepted (lower-case only — 'ALL' is rejected, not
+ * silently folded) is invalid and returns null so the caller can 400.
+ *
+ * @param  mixed $rawJob  The raw $_GET['job'] value (or an equivalent test value).
+ * @return string|null    'deletion'|'retention'|'all', or null when invalid.
+ */
+function g2ml_cronNormaliseJobName(mixed $rawJob): ?string
+{
+    if ($rawJob === null)
+    {
+        return 'all';
+    }
+
+    if (!is_string($rawJob))
+    {
+        return null;
+    }
+
+    if ($rawJob === '')
+    {
+        return 'all';
+    }
+
+    $validJobNames = ['deletion', 'retention', 'all'];
+
+    if (in_array($rawJob, $validJobNames, true))
+    {
+        return $rawJob;
+    }
+
+    return null;
+}
+
+/**
+ * Emit a byte-identical generic 404 and exit.
+ *
+ * NOT pure — sends headers and terminates the request. Used for EVERY
+ * authorisation failure path (feature off, no token configured, no token
+ * presented, wrong token) so the endpoint's response can never be used as an
+ * oracle for which of those is true — it is indistinguishable from a file
+ * that does not exist.
+ *
+ * @return void  Always exits — never returns.
+ */
+function g2ml_cronEmitNotFound(): void
+{
+    http_response_code(404);
+    header('Content-Type: text/plain; charset=utf-8');
+    echo 'Not Found';
+    exit;
+}
+
+// ============================================================================
+// 🔒 Concurrency — MySQL Advisory Lock
+// ============================================================================
+
+/**
+ * Acquire the shared cron advisory lock with a zero-second timeout.
+ *
+ * Uses GET_LOCK(CONCAT(DATABASE(), ':g2ml_cron'), 0). The DATABASE() prefix
+ * namespaces the lock name on a shared MySQL server (Dreamhost hosts many
+ * schemas per server); a zero timeout means this call NEVER blocks — it
+ * either acquires immediately or fails immediately, so a caller that loses
+ * the race short-circuits to a 'skipped' report rather than queuing. The lock
+ * is automatically released by MySQL if the holding connection dies, so a
+ * killed FastCGI worker can never leave the job permanently locked.
+ *
+ * @return bool  True only when GET_LOCK() returned integer 1.
+ *
+ * 📖 Reference: https://dev.mysql.com/doc/refman/8.0/en/locking-functions.html#function_get-lock
+ */
+function g2ml_cronAcquireLock(): bool
+{
+    $row = dbSelectOne("SELECT GET_LOCK(CONCAT(DATABASE(), ':g2ml_cron'), 0) AS lockResult", '', []);
+
+    if (!is_array($row))
+    {
+        return false;
+    }
+
+    return ((int) $row['lockResult']) === 1;
+}
+
+/**
+ * Release the shared cron advisory lock. Best-effort — the lock self-releases
+ * on connection close regardless, so a failure here is not fatal to anything.
+ *
+ * @return void
+ *
+ * 📖 Reference: https://dev.mysql.com/doc/refman/8.0/en/locking-functions.html#function_release-lock
+ */
+function g2ml_cronReleaseLock(): void
+{
+    dbSelectOne("SELECT RELEASE_LOCK(CONCAT(DATABASE(), ':g2ml_cron')) AS releaseResult", '', []);
+}
+
+// ============================================================================
+// 🧮 Setting Clamps (PURE — unit-testable fail-safes)
+// ============================================================================
+
+/**
+ * PURE — resolve the effective grace-period (in days) a deletion request must
+ * sit for before it becomes eligible for execution.
+ *
+ * Any non-numeric value, or a value outside the sane [1, 365] window, falls
+ * back to the published default of 30 — this NEVER lets a misconfigured
+ * setting shrink the grace window to 0 (which would let a request be
+ * executed the instant it is created, defeating the cancellation window the
+ * confirmation email promises) or silently balloon it to something absurd.
+ *
+ * @param  mixed $settingValue  The raw compliance.data_deletion_grace_days value.
+ * @return int                  A grace period in days, always within [1, 365].
+ */
+function g2ml_cronEffectiveGraceDays(mixed $settingValue): int
+{
+    if (!is_numeric($settingValue))
+    {
+        return 30;
+    }
+
+    $graceDays = (int) $settingValue;
+
+    if ($graceDays < 1)
+    {
+        return 30;
+    }
+
+    if ($graceDays > 365)
+    {
+        return 30;
+    }
+
+    return $graceDays;
+}
+
+/**
+ * PURE — resolve the deletion executor's operating mode from its two gate
+ * settings.
+ *
+ * Fail-safe by construction: the enabled flag must be the exact boolean
+ * `true` to leave 'disabled', and the dry-run flag must be the exact boolean
+ * `false` to unlock 'live' — anything else (missing, null, the string '0', an
+ * integer, an object) is treated as "still dry-run", never as "live". This
+ * means a setting read that returns an unexpected type (e.g. a settings-cache
+ * miss returning the caller's own default) can never accidentally authorise
+ * an irreversible run.
+ *
+ * @param  mixed $enabledSetting  getSetting('gdpr.deletion_job_enabled', false).
+ * @param  mixed $dryRunSetting   getSetting('gdpr.deletion_job_dry_run', true).
+ * @return string                 'disabled' | 'dry-run' | 'live'.
+ */
+function g2ml_cronDeletionMode(mixed $enabledSetting, mixed $dryRunSetting): string
+{
+    if ($enabledSetting !== true)
+    {
+        return 'disabled';
+    }
+
+    if ($dryRunSetting !== false)
+    {
+        return 'dry-run';
+    }
+
+    return 'live';
+}
+
+/**
+ * PURE — clamp a raw setting value to an integer within [$min, $max],
+ * falling back to $fallback when the raw value is not numeric.
+ *
+ * Used for every bounded integer setting in this file: the deletion batch
+ * size (1–100), the retention batch size (50–2000), time budgets, AND the
+ * probabilistic divisor (called with $min = 0 so a configured value of 0 or
+ * below clamps to exactly 0 — the divisor's own "disabled" sentinel — while a
+ * non-numeric value still falls back to a sane default rather than to 0).
+ *
+ * @param  mixed $value     The raw setting value.
+ * @param  int   $min       The minimum accepted value (inclusive).
+ * @param  int   $max       The maximum accepted value (inclusive).
+ * @param  int   $fallback  Returned when $value is not numeric.
+ * @return int              A value within [$min, $max], or $fallback.
+ */
+function g2ml_cronClampInt(mixed $value, int $min, int $max, int $fallback): int
+{
+    if (!is_numeric($value))
+    {
+        return $fallback;
+    }
+
+    $intValue = (int) $value;
+
+    if ($intValue < $min)
+    {
+        return $min;
+    }
+
+    if ($intValue > $max)
+    {
+        return $max;
+    }
+
+    return $intValue;
+}
+
+// ============================================================================
+// 🚦 Dispatch
+// ============================================================================
+
+/**
+ * Run the requested job(s) and assemble the run report.
+ *
+ * Under job='all', deletion runs BEFORE retention — the erasure SLA outranks
+ * housekeeping. Each sub-job re-checks its OWN enable gate internally;
+ * dispatch never overrides or bypasses them. Retention receives whatever
+ * time budget remains after deletion returns (floored at 1 second) so a slow
+ * deletion pass cannot starve retention of its own accounting entirely.
+ *
+ * @param  string $jobName            'deletion' | 'retention' | 'all'.
+ * @param  int    $timeBudgetSeconds  The overall soft time budget for this run.
+ * @return array                      {status, environment, jobName, startedAt,
+ *                                     elapsedMs, partial, jobs: {...}}
+ */
+function g2ml_cronRunJobs(string $jobName, int $timeBudgetSeconds): array
+{
+    $startedAt = gmdate('Y-m-d H:i:s');
+    $startTime = microtime(true);
+    $deadline  = $startTime + $timeBudgetSeconds;
+
+    $environment = 'unknown';
+
+    if (function_exists('g2ml_getEnvironment'))
+    {
+        $environment = g2ml_getEnvironment();
+    }
+
+    $jobs    = [];
+    $partial = false;
+
+    if ($jobName === 'all' || $jobName === 'deletion')
+    {
+        $jobs['deletion'] = g2ml_cronRunDeletionJob($timeBudgetSeconds);
+
+        if (($jobs['deletion']['partial'] ?? false) === true)
+        {
+            $partial = true;
+        }
+    }
+
+    if ($jobName === 'all' || $jobName === 'retention')
+    {
+        $remainingSeconds = (int) round($deadline - microtime(true));
+
+        if ($remainingSeconds < 1)
+        {
+            $remainingSeconds = 1;
+        }
+
+        $batchSize = g2ml_cronClampInt(getSetting('retention.batch_size', 500), 50, 2000, 500);
+
+        $jobs['retention'] = g2ml_cronRunRetentionJob($remainingSeconds, $batchSize);
+
+        if (($jobs['retention']['partial'] ?? false) === true)
+        {
+            $partial = true;
+        }
+    }
+
+    $elapsedMs = (int) round((microtime(true) - $startTime) * 1000);
+
+    return [
+        'status'      => 'ok',
+        'environment' => $environment,
+        'jobName'     => $jobName,
+        'startedAt'   => $startedAt,
+        'elapsedMs'   => $elapsedMs,
+        'partial'     => $partial,
+        'jobs'        => $jobs,
+    ];
+}
+
+// ============================================================================
+// 🗑️ #163 Deletion Executor
+// ============================================================================
+
+/**
+ * Run the GDPR deletion executor, subject to ALL of interlocks I3–I11 (I1/I2
+ * — the endpoint master switch and token auth — are enforced by the endpoint
+ * BEFORE this is ever called; see cron.php's own docblock for the full list).
+ *
+ * Control flow:
+ *   1. Resolve the mode (disabled/dry-run/live) — disabled returns immediately,
+ *      touching nothing.
+ *   2. Resolve the grace period and select due rows (requestType='deletion',
+ *      status='pending', older than the grace window) — I6.
+ *   3. Dry-run: log what WOULD be processed per row (data_deletion_due_dryrun)
+ *      and return — NO writes to any subject data, NO status change.
+ *   4. Live: resolve and validate the configured actor UID — refuses to start
+ *      (I5) unless it references a real tblUsers row. Then, per row, bounded
+ *      by the batch cap (I10) and the time budget, calls the EXISTING
+ *      g2ml_processDataDeletion() (data_rights.php) — no reimplementation.
+ *      That function re-checks status='pending' itself (I8) and
+ *      g2ml_anonymiseUserData() is already transactional (I9). One failed row
+ *      is logged and does not stop the batch.
+ *   5. Full logging throughout (I11): per-row activity rows plus a run
+ *      summary.
+ *
+ * Known edge case (by design, not a bug): if g2ml_processDataDeletion()'s
+ * internal status UPDATE fails after a successful anonymise, the next run
+ * re-selects the same row and re-anonymises it — harmless, because
+ * g2ml_anonymiseUserData() is idempotent, making this a self-healing retry
+ * rather than a hazard.
+ *
+ * The tblDataDeletionRequests.requestType enum also allows 'anonymisation',
+ * but no code path in this application ever inserts that value — this
+ * function deliberately only ever selects requestType='deletion'.
+ *
+ * @param  int $timeBudgetSeconds  Soft time budget for the live-mode loop.
+ * @return array                   A job report (shape varies by mode/outcome).
+ */
+function g2ml_cronRunDeletionJob(int $timeBudgetSeconds): array
+{
+    $enabledSetting = getSetting('gdpr.deletion_job_enabled', false);
+    $dryRunSetting  = getSetting('gdpr.deletion_job_dry_run', true);
+
+    $mode = g2ml_cronDeletionMode($enabledSetting, $dryRunSetting);
+
+    if ($mode === 'disabled')
+    {
+        return ['enabled' => false];
+    }
+
+    $graceDays  = g2ml_cronEffectiveGraceDays(getSetting('compliance.data_deletion_grace_days', 30));
+    $batchLimit = g2ml_cronClampInt(getSetting('gdpr.deletion_job_batch', 10), 1, 100, 10);
+
+    $dueRequests = g2ml_cronFindDueDeletionRequests($graceDays, $batchLimit);
+
+    if ($dueRequests === false)
+    {
+        error_log('[Go2My.Link] ERROR: g2ml_cronRunDeletionJob — failed to query due deletion requests.');
+
+        return [
+            'enabled' => true,
+            'mode'    => $mode,
+            'error'   => 'query_failed',
+        ];
+    }
+
+    if ($mode === 'dry-run')
+    {
+        $wouldProcess = [];
+
+        foreach ($dueRequests as $dueRequest)
+        {
+            $requestUID = (int) $dueRequest['requestUID'];
+
+            logActivity('data_deletion_due_dryrun', 'success', null, [
+                'userUID' => (int) $dueRequest['userUID'],
+                'logData' => [
+                    'requestUID'        => $requestUID,
+                    'requestedAt'       => $dueRequest['createdAt'],
+                    'eligibleSinceDays' => $graceDays,
+                ],
+            ]);
+
+            $wouldProcess[] = $requestUID;
+        }
+
+        return [
+            'enabled'      => true,
+            'mode'         => $mode,
+            'due'          => count($dueRequests),
+            'wouldProcess' => $wouldProcess,
+        ];
+    }
+
+    // ------------------------------------------------------------------------
+    // Live mode only from here — I5: refuse to start unless the configured
+    // actor UID references a real tblUsers row.
+    // ------------------------------------------------------------------------
+    $actorUIDSetting = getSetting('gdpr.deletion_job_actor_uid', null);
+
+    $actorUID = 0;
+
+    if (is_numeric($actorUIDSetting))
+    {
+        $actorUID = (int) $actorUIDSetting;
+    }
+
+    $actorRow = null;
+
+    if ($actorUID > 0)
+    {
+        $actorRow = dbSelectOne('SELECT userUID FROM tblUsers WHERE userUID = ?', 'i', [$actorUID]);
+    }
+
+    if ($actorUID <= 0 || !is_array($actorRow))
+    {
+        error_log('[Go2My.Link] ERROR: g2ml_cronRunDeletionJob — gdpr.deletion_job_actor_uid is unset or does not reference a real user; refusing to run live.');
+
+        logActivity('cron_deletion_job_run', 'error', null, [
+            'logData' => ['error' => 'actor_not_configured'],
+        ]);
+
+        return [
+            'enabled' => true,
+            'mode'    => $mode,
+            'error'   => 'actor_not_configured',
+        ];
+    }
+
+    // ------------------------------------------------------------------------
+    // I10 — batch cap already applied to the SELECT (LIMIT $batchLimit);
+    // I7 is the caller's advisory lock; I6 is already baked into the WHERE
+    // clause of g2ml_cronFindDueDeletionRequests(). Bound the LOOP itself by
+    // the time budget so a slow batch stops cleanly rather than overrunning
+    // the FastCGI request limit.
+    // ------------------------------------------------------------------------
+    $deadline  = microtime(true) + $timeBudgetSeconds;
+    $processed = 0;
+    $failed    = 0;
+    $partial   = false;
+
+    foreach ($dueRequests as $dueRequest)
+    {
+        if (microtime(true) >= $deadline)
+        {
+            $partial = true;
+            break;
+        }
+
+        $requestUID = (int) $dueRequest['requestUID'];
+        $userUID    = (int) $dueRequest['userUID'];
+
+        // I8/I9 — g2ml_processDataDeletion() re-reads and requires
+        // status='pending' itself, and its anonymisation call is already
+        // transactional. No reimplementation here.
+        $success = g2ml_processDataDeletion($requestUID, $actorUID);
+
+        if ($success === true)
+        {
+            $status    = 'success';
+            $processed = $processed + 1;
+        }
+        else
+        {
+            $status = 'failed';
+            $failed = $failed + 1;
+            error_log('[Go2My.Link] ERROR: g2ml_cronRunDeletionJob — g2ml_processDataDeletion failed for requestUID ' . $requestUID);
+        }
+
+        logActivity('data_deletion_executed', $status, null, [
+            'userUID' => $userUID,
+            'logData' => ['requestUID' => $requestUID],
+        ]);
+    }
+
+    logActivity('cron_deletion_job_run', 'success', null, [
+        'logData' => [
+            'mode'      => $mode,
+            'due'       => count($dueRequests),
+            'processed' => $processed,
+            'failed'    => $failed,
+            'partial'   => $partial,
+        ],
+    ]);
+
+    return [
+        'enabled'   => true,
+        'mode'      => $mode,
+        'due'       => count($dueRequests),
+        'processed' => $processed,
+        'failed'    => $failed,
+        'partial'   => $partial,
+    ];
+}
+
+/**
+ * Select the oldest pending deletion requests that have already cleared their
+ * grace period, oldest (closest to SLA breach) first.
+ *
+ * Only requestType='deletion' rows are ever selected — 'export' rows and the
+ * (never-inserted) 'anonymisation' enum value are excluded by the WHERE
+ * clause itself, not by post-filtering.
+ *
+ * @param  int         $graceDays   The grace period in days (already clamped
+ *                                  by g2ml_cronEffectiveGraceDays()).
+ * @param  int         $batchLimit  Maximum rows to return (already clamped by
+ *                                  g2ml_cronClampInt()).
+ * @return array|false              Rows of {requestUID, userUID, createdAt},
+ *                                  or false on a query error.
+ */
+function g2ml_cronFindDueDeletionRequests(int $graceDays, int $batchLimit): array|false
+{
+    return dbSelect(
+        "SELECT requestUID, userUID, createdAt
+           FROM tblDataDeletionRequests
+          WHERE requestType = 'deletion'
+            AND status = 'pending'
+            AND createdAt <= DATE_SUB(NOW(), INTERVAL ? DAY)
+          ORDER BY createdAt ASC
+          LIMIT ?",
+        'ii',
+        [$graceDays, $batchLimit]
+    );
+}
+
+// ============================================================================
+// 🧹 #167 Retention Sweeps
+// ============================================================================
+
+/**
+ * Run every retention sweep, gated behind the single master switch
+ * retention.enforcement_enabled. All sweeps are idempotent — re-running
+ * converges (their WHERE clauses exclude already-treated rows) — so there is
+ * no harm in this being called from BOTH the endpoint and the probabilistic
+ * page_init.php hook.
+ *
+ * @param  int $timeBudgetSeconds  Overall soft time budget for this call.
+ * @param  int $batchSize          LIMIT per UPDATE/DELETE chunk (already
+ *                                 clamped by the caller).
+ * @return array                   {enabled, partial, anonymise, purge, exports, sessions}
+ */
+function g2ml_cronRunRetentionJob(int $timeBudgetSeconds, int $batchSize): array
+{
+    $enforcementEnabled = getSetting('retention.enforcement_enabled', false);
+
+    if ($enforcementEnabled !== true)
+    {
+        return ['enabled' => false];
+    }
+
+    $deadline = microtime(true) + $timeBudgetSeconds;
+
+    $anonymiseDays = g2ml_cronClampInt(getSetting('retention.activity_log_anonymise_days', 90), 0, 3650, 90);
+    $purgeDays     = g2ml_cronClampInt(getSetting('retention.activity_log_purge_days', 0), 0, 3650, 0);
+
+    $anonymiseReport = g2ml_retentionAnonymiseActivityLog($anonymiseDays, $batchSize, $deadline);
+
+    $purgeReport = [];
+
+    if ($purgeDays <= 0)
+    {
+        $purgeReport = ['skipped' => 'disabled'];
+    }
+    elseif ($purgeDays < $anonymiseDays)
+    {
+        // Misconfiguration guard: purging rows the anonymise sweep has not
+        // yet reached would destroy detailed data the policy still promises
+        // to keep (anonymised) up to the anonymise window.
+        error_log(
+            '[Go2My.Link] WARNING: g2ml_cronRunRetentionJob — retention.activity_log_purge_days ('
+            . $purgeDays . ') is less than retention.activity_log_anonymise_days ('
+            . $anonymiseDays . '); skipping the purge sweep this run.'
+        );
+
+        $purgeReport = ['skipped' => 'misconfigured'];
+    }
+    else
+    {
+        $purgeReport = g2ml_retentionPurgeActivityLog($purgeDays, $batchSize, $deadline);
+    }
+
+    $exportReport   = g2ml_retentionPurgeExpiredExports($deadline);
+    $sessionsReport = g2ml_retentionCleanSessions();
+
+    $partial = false;
+
+    $partialCandidates = [$anonymiseReport, $purgeReport, $exportReport];
+
+    foreach ($partialCandidates as $subReport)
+    {
+        if (($subReport['partial'] ?? false) === true)
+        {
+            $partial = true;
+        }
+    }
+
+    return [
+        'enabled'   => true,
+        'partial'   => $partial,
+        'anonymise' => $anonymiseReport,
+        'purge'     => $purgeReport,
+        'exports'   => $exportReport,
+        'sessions'  => $sessionsReport,
+    ];
+}
+
+/**
+ * Anonymise (NOT delete) tblActivityLog rows older than $olderThanDays:
+ * ipAddress → '0.0.0.0' (the same sentinel g2ml_anonymiseUserData() already
+ * uses) and requestUserAgent → NULL. Rows themselves are kept so the
+ * aggregate columns (countryCode, deviceType, browserName, …) survive for
+ * analytics, matching the published "90 days detailed, then aggregated"
+ * promise.
+ *
+ * Idempotent by construction: the `ipAddress <> '0.0.0.0'` predicate drops
+ * already-anonymised rows out of the working set, so re-running converges to
+ * zero affected rows and stays cheap. Uses the existing IDX_log_created index
+ * — no new index or migration required.
+ *
+ * @param  int   $olderThanDays  Age threshold in days. 0 disables this sweep.
+ * @param  int   $batchSize      LIMIT per UPDATE chunk.
+ * @param  float $deadline       microtime(true) value to stop looping by.
+ * @return array                 {swept, batches, partial} or {skipped: 'disabled'}
+ */
+function g2ml_retentionAnonymiseActivityLog(int $olderThanDays, int $batchSize, float $deadline): array
+{
+    if ($olderThanDays <= 0)
+    {
+        return ['skipped' => 'disabled'];
+    }
+
+    $totalSwept = 0;
+    $batches    = 0;
+    $partial    = false;
+
+    while (true)
+    {
+        if (microtime(true) >= $deadline)
+        {
+            $partial = true;
+            break;
+        }
+
+        $affected = dbUpdate(
+            "UPDATE tblActivityLog
+                SET ipAddress = '0.0.0.0', requestUserAgent = NULL
+              WHERE createdAt < DATE_SUB(NOW(), INTERVAL ? DAY)
+                AND ipAddress <> '0.0.0.0'
+              LIMIT ?",
+            'ii',
+            [$olderThanDays, $batchSize]
+        );
+
+        if ($affected === false)
+        {
+            error_log('[Go2My.Link] ERROR: g2ml_retentionAnonymiseActivityLog — UPDATE failed.');
+            break;
+        }
+
+        $totalSwept = $totalSwept + $affected;
+        $batches    = $batches + 1;
+
+        if ($affected < $batchSize)
+        {
+            break;
+        }
+    }
+
+    return ['swept' => $totalSwept, 'batches' => $batches, 'partial' => $partial];
+}
+
+/**
+ * Permanently DELETE tblActivityLog rows older than $olderThanDays.
+ *
+ * Defaults to OFF (retention.activity_log_purge_days = '0') — see the
+ * design's owner sign-off item on the anonymise-vs-purge policy mismatch.
+ * The caller (g2ml_cronRunRetentionJob()) already refuses to invoke this
+ * unless the purge window is >= the anonymise window, so a row reaching this
+ * DELETE has already been anonymised for at least that many days.
+ *
+ * @param  int   $olderThanDays  Age threshold in days. 0 disables this sweep.
+ * @param  int   $batchSize      LIMIT per DELETE chunk.
+ * @param  float $deadline       microtime(true) value to stop looping by.
+ * @return array                 {swept, batches, partial} or {skipped: 'disabled'}
+ */
+function g2ml_retentionPurgeActivityLog(int $olderThanDays, int $batchSize, float $deadline): array
+{
+    if ($olderThanDays <= 0)
+    {
+        return ['skipped' => 'disabled'];
+    }
+
+    $totalSwept = 0;
+    $batches    = 0;
+    $partial    = false;
+
+    while (true)
+    {
+        if (microtime(true) >= $deadline)
+        {
+            $partial = true;
+            break;
+        }
+
+        $affected = dbDelete(
+            "DELETE FROM tblActivityLog
+              WHERE createdAt < DATE_SUB(NOW(), INTERVAL ? DAY)
+              LIMIT ?",
+            'ii',
+            [$olderThanDays, $batchSize]
+        );
+
+        if ($affected === false)
+        {
+            error_log('[Go2My.Link] ERROR: g2ml_retentionPurgeActivityLog — DELETE failed.');
+            break;
+        }
+
+        $totalSwept = $totalSwept + $affected;
+        $batches    = $batches + 1;
+
+        if ($affected < $batchSize)
+        {
+            break;
+        }
+    }
+
+    return ['swept' => $totalSwept, 'batches' => $batches, 'partial' => $partial];
+}
+
+/**
+ * Sweep expired data-export bundles: for every tblDataDeletionRequests row
+ * with requestType='export' whose exportExpiresAt has passed, confine the
+ * stored path to the exports directory (g2ml_retentionPathIsConfined() — the
+ * same strncmp guard g2ml_streamExportDownload() already uses), unlink the
+ * file if present, then NULL exportFilePath on the row (the row itself is
+ * kept as an audit trail). A path that fails confinement is NEVER unlinked —
+ * only logged — and its DB path is left untouched for investigation.
+ *
+ * Also sweeps orphaned export_*.json files with no matching DB row at all
+ * (covers files left behind by any pre-#162-era code path), once they are
+ * older than the configured export-expiry window
+ * (compliance.data_export_expiry_hours).
+ *
+ * @param  float $deadline  microtime(true) value to stop looping by.
+ * @return array            {swept, orphansSwept, partial}
+ */
+function g2ml_retentionPurgeExpiredExports(float $deadline): array
+{
+    $exportsDir     = G2ML_UPLOADS . DIRECTORY_SEPARATOR . 'exports';
+    $realExportsDir = realpath($exportsDir);
+
+    $swept   = 0;
+    $partial = false;
+
+    $expiredRows = dbSelect(
+        "SELECT requestUID, exportFilePath
+           FROM tblDataDeletionRequests
+          WHERE requestType = 'export'
+            AND exportFilePath IS NOT NULL
+            AND exportExpiresAt IS NOT NULL
+            AND exportExpiresAt < NOW()
+          LIMIT 50",
+        '',
+        []
+    );
+
+    if ($expiredRows === false)
+    {
+        error_log('[Go2My.Link] ERROR: g2ml_retentionPurgeExpiredExports — failed to query expired export rows.');
+        $expiredRows = [];
+    }
+
+    foreach ($expiredRows as $expiredRow)
+    {
+        if (microtime(true) >= $deadline)
+        {
+            $partial = true;
+            break;
+        }
+
+        $requestUID = (int) $expiredRow['requestUID'];
+        $filePath   = (string) $expiredRow['exportFilePath'];
+
+        if ($realExportsDir !== false)
+        {
+            $realFilePath = realpath($filePath);
+
+            if ($realFilePath !== false && g2ml_retentionPathIsConfined($realExportsDir, $realFilePath))
+            {
+                if (is_file($realFilePath))
+                {
+                    unlink($realFilePath);
+                }
+            }
+            elseif ($realFilePath !== false)
+            {
+                error_log(
+                    '[Go2My.Link] ERROR: g2ml_retentionPurgeExpiredExports — exportFilePath escapes the exports '
+                    . 'directory for requestUID ' . $requestUID . '; leaving the file untouched.'
+                );
+            }
+        }
+
+        dbUpdate(
+            "UPDATE tblDataDeletionRequests SET exportFilePath = NULL WHERE requestUID = ?",
+            'i',
+            [$requestUID]
+        );
+
+        $swept = $swept + 1;
+    }
+
+    // ------------------------------------------------------------------------
+    // Orphan sweep — files on disk with no matching DB row at all.
+    // ------------------------------------------------------------------------
+    $orphansSwept = 0;
+
+    $expiryHours = g2ml_cronClampInt(getSetting('compliance.data_export_expiry_hours', 48), 1, 8760, 48);
+    $expirySeconds = $expiryHours * 3600;
+
+    if ($realExportsDir !== false && is_dir($realExportsDir))
+    {
+        $entries = scandir($realExportsDir);
+
+        if ($entries !== false)
+        {
+            foreach ($entries as $entry)
+            {
+                if (microtime(true) >= $deadline)
+                {
+                    $partial = true;
+                    break;
+                }
+
+                if (preg_match('/^export_.*\.json$/', $entry) !== 1)
+                {
+                    continue;
+                }
+
+                $entryPath = $realExportsDir . DIRECTORY_SEPARATOR . $entry;
+
+                if (!is_file($entryPath))
+                {
+                    continue;
+                }
+
+                $existingRow = dbSelectOne(
+                    "SELECT requestUID FROM tblDataDeletionRequests WHERE exportFilePath = ? LIMIT 1",
+                    's',
+                    [$entryPath]
+                );
+
+                if ($existingRow !== null && $existingRow !== false)
+                {
+                    continue;
+                }
+
+                $mtime = filemtime($entryPath);
+
+                if ($mtime !== false && $mtime < (time() - $expirySeconds))
+                {
+                    unlink($entryPath);
+                    $orphansSwept = $orphansSwept + 1;
+                }
+            }
+        }
+    }
+
+    return ['swept' => $swept, 'orphansSwept' => $orphansSwept, 'partial' => $partial];
+}
+
+/**
+ * Thin wrapper over the existing cleanExpiredSessions() (session.php),
+ * exposed here so g2ml_cronRunRetentionJob() reports a session-sweep count
+ * alongside the other retention sweeps. The existing 1-in-100 probabilistic
+ * call already inside page_init.php is left completely untouched (belt and
+ * braces — this is deliberately a duplicate safety net, not a replacement).
+ *
+ * @return array  {swept}
+ */
+function g2ml_retentionCleanSessions(): array
+{
+    $swept = 0;
+
+    if (function_exists('cleanExpiredSessions'))
+    {
+        $swept = cleanExpiredSessions();
+    }
+
+    return ['swept' => $swept];
+}
+
+/**
+ * PURE — confinement check: is $realFilePath located inside $realBaseDir?
+ *
+ * Mirrors g2ml_streamExportDownload()'s own strncmp() guard
+ * (data_rights.php) exactly, including appending the trailing directory
+ * separator to the base directory before comparing — WITHOUT that trailing
+ * separator, a sibling directory that merely shares the same string prefix
+ * (e.g. "/exports" matching against "/exports_evil/file") would incorrectly
+ * pass as "confined". Both arguments are expected to already be realpath()-
+ * resolved by the caller; this function does no I/O itself, so it is fully
+ * unit-testable without touching disk.
+ *
+ * @param  string $realBaseDir   The confining directory (already realpath()'d).
+ * @param  string $realFilePath  The candidate file path (already realpath()'d).
+ * @return bool                  True only when $realFilePath is inside $realBaseDir.
+ */
+function g2ml_retentionPathIsConfined(string $realBaseDir, string $realFilePath): bool
+{
+    if ($realBaseDir === '' || $realFilePath === '')
+    {
+        return false;
+    }
+
+    $confinedPrefix = rtrim($realBaseDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+
+    return (strncmp($realFilePath, $confinedPrefix, strlen($confinedPrefix)) === 0);
+}
+
+// ============================================================================
+// 🎲 Probabilistic Fallback (page_init.php hook)
+// ============================================================================
+
+/**
+ * Called once per request from _includes/page_init.php, AFTER
+ * loadSettingsCache() has run (unlike the pre-settings 1% session hook this
+ * mirrors — retention needs its settings available first). Runs RETENTION
+ * ONLY — this NEVER touches the #163 deletion job; that executor is
+ * endpoint-only by design (see this file's own top docblock).
+ *
+ * Early-out order (cheapest checks first, mirroring api_ratelimit.php's own
+ * probabilistic prune):
+ *   1. The dispatch endpoint marks itself with G2ML_CRON_DISPATCH before
+ *      page_init.php runs — if set, this request already IS the endpoint
+ *      run, so return immediately (no self-race for the advisory lock).
+ *   2. Clamp retention.probabilistic_divisor; <= 0 means the fallback path is
+ *      disabled entirely.
+ *   3. Roll mt_rand(1, divisor) — only a 1-in-divisor chance continues.
+ *   4. Check retention.enforcement_enabled — the master gate.
+ *   5. Try to acquire the advisory lock — if another run already holds it,
+ *      skip quietly rather than compete or queue.
+ *   6. Run the retention job with the fallback time budget, then release the
+ *      lock in a finally block.
+ *
+ * @return void
+ */
+function g2ml_cronMaybeRunProbabilisticRetention(): void
+{
+    if (defined('G2ML_CRON_DISPATCH'))
+    {
+        return;
+    }
+
+    $divisor = g2ml_cronClampInt(getSetting('retention.probabilistic_divisor', 500), 0, PHP_INT_MAX, 500);
+
+    if ($divisor <= 0)
+    {
+        return;
+    }
+
+    if (mt_rand(1, $divisor) !== 1)
+    {
+        return;
+    }
+
+    $enforcementEnabled = getSetting('retention.enforcement_enabled', false);
+
+    if ($enforcementEnabled !== true)
+    {
+        return;
+    }
+
+    if (g2ml_cronAcquireLock() !== true)
+    {
+        return;
+    }
+
+    try
+    {
+        $timeBudget = g2ml_cronClampInt(getSetting('retention.fallback_time_budget_seconds', 2), 1, 30, 2);
+        $batchSize  = g2ml_cronClampInt(getSetting('retention.batch_size', 500), 50, 2000, 500);
+
+        g2ml_cronRunRetentionJob($timeBudget, $batchSize);
+    }
+    finally
+    {
+        g2ml_cronReleaseLock();
+    }
+}

--- a/web/_includes/page_init.php
+++ b/web/_includes/page_init.php
@@ -251,6 +251,16 @@ require_once G2ML_FUNCTIONS . DIRECTORY_SEPARATOR . 'entitlements.php';
 // Layer 4 — Compliance, Privacy & Security Response (depend on Layers 1+2+3)
 require_once G2ML_FUNCTIONS . DIRECTORY_SEPARATOR . 'cookie_consent.php';
 require_once G2ML_FUNCTIONS . DIRECTORY_SEPARATOR . 'data_rights.php';
+
+// Scheduled jobs (#163 GDPR deletion executor + #167 retention sweeps).
+// Guarded require_once so a partially-deployed tree (file missing) degrades
+// to a no-op rather than a fatal error — the probabilistic hook below is
+// itself function_exists()-guarded for the same reason.
+if (file_exists(G2ML_FUNCTIONS . DIRECTORY_SEPARATOR . 'cron.php'))
+{
+    require_once G2ML_FUNCTIONS . DIRECTORY_SEPARATOR . 'cron.php';
+}
+
 require_once G2ML_FUNCTIONS . DIRECTORY_SEPARATOR . 'breach_response.php';
 require_once G2ML_FUNCTIONS . DIRECTORY_SEPARATOR . 'linkspage_manage.php';
 
@@ -350,6 +360,22 @@ if (function_exists('cleanExpiredSessions') && mt_rand(1, 100) === 1)
 // ============================================================================
 
 loadSettingsCache();
+
+// ============================================================================
+// 🧹 Step 8.5: Probabilistic Retention Fallback (#167 / #178)
+// ============================================================================
+// Mirrors the existing 1% session-cleanup idiom above, but MUST run AFTER
+// loadSettingsCache() (unlike that hook, which needs no settings at all) —
+// this hook's very first checks read retention.* settings. Inert unless
+// retention.enforcement_enabled is explicitly on; see cron.php for the full
+// gate chain. NEVER runs the #163 deletion job — that executor is
+// endpoint-only by design (web/Go2My.Link/_admin/public_html/cron.php).
+// ============================================================================
+
+if (function_exists('g2ml_cronMaybeRunProbabilisticRetention'))
+{
+    g2ml_cronMaybeRunProbabilisticRetention();
+}
 
 // ============================================================================
 // 🌍 Step 9: Detect and Set Locale

--- a/web/_sql/seeds/020_cron_gdpr_settings.sql
+++ b/web/_sql/seeds/020_cron_gdpr_settings.sql
@@ -1,0 +1,108 @@
+-- Copyright (c) 2024–2026 MWBM Partners Ltd (MWservices).
+-- All rights reserved.
+--
+-- This source code is proprietary and confidential.
+-- Unauthorised copying, modification, or distribution is strictly prohibited.
+
+-- ============================================================================
+-- ⏰ Go2My.Link — Scheduled Jobs / GDPR Deletion + Retention Settings (#163, #167)
+-- ============================================================================
+-- Every setting below defaults OFF/safe. A fresh install with this seed
+-- applied changes NOTHING until an operator explicitly flips settings, in the
+-- order documented in the design runbook (HANDOFF.md / issue #178):
+--
+--   1. cron.enabled = '0' and cron.dispatch_token = NULL — the dispatch
+--      endpoint (web/Go2My.Link/_admin/public_html/cron.php) answers a
+--      byte-identical generic 404 to every request until BOTH are set.
+--   2. gdpr.deletion_job_enabled = '0' AND gdpr.deletion_job_dry_run = '1' —
+--      the #163 deletion executor is double-gated. Even once "enabled", it
+--      only LOGS what it would do (data_deletion_due_dryrun) until dry_run is
+--      explicitly set to the string '0' (which getSetting() casts to boolean
+--      false — the ONLY value that unlocks live/irreversible processing).
+--   3. retention.enforcement_enabled = '0' — the #167 master gate for every
+--      retention sweep, on BOTH the endpoint and the probabilistic
+--      page_init.php fallback path.
+--
+-- gdpr.deletion_job_actor_uid is seeded NULL deliberately: a live deletion
+-- run refuses to start at all while it is unset (see cron.php's
+-- g2ml_cronRunDeletionJob() — I5), because tblDataDeletionRequests.
+-- processedByUserUID is a real FK to tblUsers and a fake/absent UID must fail
+-- cleanly before touching any row, not rely on the FK to reject it.
+--
+-- Uses ON DUPLICATE KEY UPDATE (description only) for idempotent re-runs —
+-- exact house pattern from 017_geolocation_settings.sql — so re-applying this
+-- seed on an already-configured instance never clobbers an operator's chosen
+-- values.
+--
+-- @package    Go2My.Link
+-- @subpackage Seeds
+-- @version    1.0.0
+-- @since      v1.7.0 — GDPR Scheduled Jobs (#163, #167)
+--
+-- 📖 References:
+--     - Job library:   web/_functions/cron.php
+--     - Endpoint:      web/Go2My.Link/_admin/public_html/cron.php
+--     - tblSettings:   web/_sql/schema/010_core_settings.sql
+-- ============================================================================
+
+USE `mwtools_Go2MyLink`;
+
+INSERT INTO `tblSettings` (
+    `settingID`, `settingScope`, `settingScopeRef`,
+    `settingValue`, `settingDefault`, `settingDescription`,
+    `settingDataType`, `isSensitive`, `isEditable`
+) VALUES
+('cron.enabled', 'System', NULL, '0', '0',
+ 'Master switch for the scheduled-jobs dispatch endpoint (admin.go2my.link/cron.php). OFF by default — the endpoint answers a byte-identical generic 404 for every request until this is 1 AND cron.dispatch_token is set.',
+ 'boolean', 0, 1),
+
+('cron.dispatch_token', 'System', NULL, NULL, NULL,
+ 'Shared-secret token external schedulers present via the X-G2ML-Cron-Token header (preferred) or ?token= (fallback, but visible in Apache access logs). Set with setSetting(\'cron.dispatch_token\', g2ml_generateToken(), \'System\', NULL, true) so it is stored AES-256-GCM encrypted. Unset (NULL) means the endpoint can never authenticate anyone. Minimum accepted length is 32 characters — a shorter stored token fails closed rather than "works".',
+ 'string', 1, 1),
+
+('cron.max_runtime_seconds', 'System', NULL, '50', '50',
+ 'Soft time budget (seconds) per dispatch-endpoint run. Dreamhost FastCGI kills long-running requests, so jobs stop cleanly between batches and report partial:true rather than being killed mid-write. Clamped to [1, 300].',
+ 'integer', 0, 1),
+
+('gdpr.deletion_job_enabled', 'System', NULL, '0', '0',
+ 'Master gate for the #163 GDPR data-deletion executor (independent of cron.enabled — both must be on, plus a valid token, for the job to ever run). OFF by default.',
+ 'boolean', 0, 1),
+
+('gdpr.deletion_job_dry_run', 'System', NULL, '1', '1',
+ 'When true (the default), the deletion job only LOGS which pending requests it would process (data_deletion_due_dryrun) and touches nothing. ONLY an explicit boolean false unlocks live/irreversible processing — any other value (missing, null, "0" as a loosely-typed value, an integer) is treated as "still dry-run" as a fail-safe.',
+ 'boolean', 0, 1),
+
+('gdpr.deletion_job_batch', 'System', NULL, '10', '10',
+ 'Maximum number of pending deletion requests processed per run. Clamped to [1, 100] to bound the blast radius of a single run on shared hosting.',
+ 'integer', 0, 1),
+
+('gdpr.deletion_job_actor_uid', 'System', NULL, NULL, NULL,
+ 'The tblUsers.userUID recorded as processedByUserUID for automated deletions (recommend a dedicated system/admin account, not a personal login). A LIVE run refuses to start at all while this is unset or does not reference a real user — dry-run mode is unaffected. Left unset (NULL) by default.',
+ 'integer', 0, 1),
+
+('retention.enforcement_enabled', 'System', NULL, '0', '0',
+ 'Master gate for ALL #167 retention sweeps (activity-log anonymisation/purge, expired export cleanup, session cleanup), on both the dispatch endpoint and the probabilistic page_init.php fallback. OFF by default.',
+ 'boolean', 0, 1),
+
+('retention.activity_log_anonymise_days', 'System', NULL, '90', '90',
+ 'Age (days) after which tblActivityLog.ipAddress is set to 0.0.0.0 and requestUserAgent to NULL, matching the published "90 days detailed, then aggregated" promise. Rows themselves are KEPT so aggregate analytics survive. 0 disables this sweep.',
+ 'integer', 0, 1),
+
+('retention.activity_log_purge_days', 'System', NULL, '0', '0',
+ 'Age (days) after which tblActivityLog ROWS are permanently deleted. Defaults to 0 (never) — see the design owner sign-off item on the anonymise-vs-purge policy mismatch. If enabled, must be >= retention.activity_log_anonymise_days or the sweep skips itself with a logged warning.',
+ 'integer', 0, 1),
+
+('retention.batch_size', 'System', NULL, '500', '500',
+ 'Rows per UPDATE/DELETE chunk for every retention sweep. Clamped to [50, 2000].',
+ 'integer', 0, 1),
+
+('retention.probabilistic_divisor', 'System', NULL, '500', '500',
+ 'The probabilistic page_init.php retention fallback fires on a 1-in-N chance per ordinary request (mirrors the existing 1-in-100 session-cleanup idiom). 0 disables the fallback path entirely (the dispatch endpoint is unaffected).',
+ 'integer', 0, 1),
+
+('retention.fallback_time_budget_seconds', 'System', NULL, '2', '2',
+ 'Time budget (seconds) for a retention sweep riding an ordinary visitor request via the probabilistic fallback (vs cron.max_runtime_seconds on the dedicated dispatch endpoint). Clamped to [1, 30].',
+ 'integer', 0, 1)
+
+ON DUPLICATE KEY UPDATE
+    `settingDescription` = VALUES(`settingDescription`);


### PR DESCRIPTION
## 📋 Summary

Closes launch-blockers **#163** (GDPR account-deletion requests were never executed — the `data_rights.php` functions existed with zero callers) and **#167** (published data-retention periods were unenforced). Provider-agnostic (no Dreamhost cron assumed). **Everything ships inert** — nothing irreversible can run until the owner explicitly enables it.

## 🔄 Changes (7 files)

- **`web/_functions/cron.php`** — jobs library: constant-time token verify, dispatch, the #163 deletion executor, the #167 retention sweeps, a `GET_LOCK` concurrency guard, and the probabilistic hook.
- **`web/Go2My.Link/_admin/public_html/cron.php`** — standalone token-guarded endpoint (mirrors `analytics-export.php`); **generic 404 on every auth failure** (no info leak). Any external scheduler (Dreamhost Panel cron / cron-job.org / GitHub Actions `schedule:`) can hit it.
- **`web/_includes/page_init.php`** — guarded `require_once` + a 1-in-500 probabilistic **retention-only** fallback (the deletion executor is endpoint-only — irreversible work never rides an anonymous request).
- **`web/_sql/seeds/020_cron_gdpr_settings.sql`** — 13 settings, all seeded OFF/safe.
- **3 test files** — 45 unit + 17 integration tests.

## 🛡️ Safety-by-default (verified)

| Setting | Default |
|---|---|
| `cron.enabled` | `0` |
| `cron.dispatch_token` | `NULL` (auth impossible) |
| `gdpr.deletion_job_enabled` | `0` |
| `gdpr.deletion_job_dry_run` | `1` (logs, deletes nothing) |
| `retention.enforcement_enabled` | `0` |

The deletion state machine unlocks **only** on an exact boolean `enabled=true` **and** `dry_run=false`; any other value fails safe to disabled/dry-run. Token check is SHA-256 + `hash_equals()` (constant-time), min 32 chars.

## ✅ Testing

- `php -l` clean; **`php tests/run.php` → 594 passed / 0 failed** (+45 new unit tests).
- **17/17 new integration tests pass**; CI's `mysql:8` integration job runs them here.

## 🧑‍✈️ Owner sign-off before ENABLING (not before merging this inert code)

1. **Retention window conflict:** the privacy policy makes two different 90-day promises about `tblActivityLog` (anonymise vs purge). Default is anonymise-IP/keep-rows (`retention.activity_log_anonymise_days=90`), row-purge off — confirm which the policy means.
2. Where the cron token lives (recommended: `tblSettings` `isSensitive=1`, AES-256-GCM) + the enable runbook (daily minimum to hold the 30-day SLA).

## 🔗 Related

Closes #163, #167. Uses the scheduling vehicle decision from #178 (D1).

---

> Tracked on the [Go2My.Link Project Board](https://github.com/orgs/MWBMPartners/projects/4)

---
_Generated by [Claude Code](https://claude.ai/code/session_019v28sGYqnGeBSPNbGgVwgJ)_