### PR TITLE
docs: record GDPR jobs merge (#163/#167 closed) + MariaDB finding (#183)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -26,12 +26,22 @@
   price structures (PAYG-capped, lifetime, coupons, usage metering), resolver `web/_functions/pricing.php`,
   backfill from legacy columns, `Pricing_Strategy.md`. **Additive & DISABLED** (`billing.pricing_engine_enabled='0'`);
   entitlements.php behaviour byte-unchanged until the owner flips it. Enable pending sign-off (D4).
-- **Issue review complete (Fable):** 158 issues, **0 wrongly-closed**. Closed #159/#164/#166/#175;
-  filed #178 (Dreamhost scheduling decision — gates GDPR #163/#167) and #180 (pricing engine).
-- **Next up (unblocked, buildable now):** #163 GDPR deletion + #167 retention (via a token-guarded
-  cron endpoint — works with any trigger, so D1 doesn't block the *code*); #165 non-org analytics;
-  #153 phpcs. See `PRE_LAUNCH_CHECKLIST.md` for owner decisions D1–D7 and the **cross-project
-  integration contract** (CueRCode / SIGNula — repo access declined via add-repo, D6).
+- **GDPR launch-blockers CLOSED (#182 → alpha):** #163 (deletion execution) + #167 (retention) now
+  have a **token-guarded cron endpoint** + jobs library wiring the existing `data_rights.php`
+  functions, shipped **fully inert** (all `cron.*`/`gdpr.*`/`retention.*` settings OFF, deletion in
+  dry-run). 45 unit + 17 integration tests. **Activation** (enable + turn dry-run off + wire a daily
+  trigger) is an owner action — D1/#178. Deletion is endpoint-only; a 1-in-500 `page_init.php`
+  fallback runs retention only.
+- **⚠️ New finding #183 (potential install blocker):** `036_pricing_engine.sql`'s STORED generated
+  column `effectiveFromKey` imports on `mysql:8` (our only CI engine) but is reported to **fail on
+  MariaDB 10.11** — and Dreamhost runs MariaDB. Fix = explicit `CAST(... AS DATETIME)` **+ add
+  MariaDB to the integration CI matrix**. Pricing ships disabled but the schema imports regardless,
+  so this is install-time. **This is the recommended next task.**
+- **Issue review complete (Fable):** 158 issues, **0 wrongly-closed**. Closed #159/#163/#164/#166/#167/#175;
+  filed #178 (scheduling decision), #180 (pricing engine), #183 (MariaDB portability).
+- **Still-open next steps:** #183 (MariaDB fix) → #165 non-org analytics → #153 phpcs. See
+  `PRE_LAUNCH_CHECKLIST.md` for owner decisions D1–D7 + the **cross-project integration contract**
+  (CueRCode / SIGNula — repo access declined via add-repo, D6).
 - ⚠️ Still true: do **NOT** merge stale `main` down into `alpha`/`beta`.
 
 **State in one line:** the codebase is in good shape and the recovery is verified, but launch is

--- a/PRE_LAUNCH_CHECKLIST.md
+++ b/PRE_LAUNCH_CHECKLIST.md
@@ -49,23 +49,26 @@
 | ✅ **#176 → `alpha`** (#175, #164) | CI now runs the **528-test unit suite** (required) + an **advisory `mysql:8` integration job**; seeded the 5 missing analytics i18n keys. |
 | ✅ **#177 → `alpha`** (#166) | Short URLs can no longer be minted on **unverified** custom domains (creation now mirrors the resolver's `verificationStatus='verified'` gate → no more dead links). |
 | ✅ **#179 → `alpha`** (#180) | **Flexible pricing/entitlement engine** — 10-table data-driven model (unlimited tiers/features/price structures incl. PAYG-capped, lifetime, coupons, usage metering), resolver, backfill, `Pricing_Strategy.md`. **Additive & DISABLED by default**; CI green incl. schema import. |
-| ✅ **Issue hygiene** | Closed #159 (delivered), #164, #166, #175; filed #178 (scheduling decision), #180 (pricing engine). Full open+closed backlog review done (Fable) — **0 wrongly-closed issues**. |
+| ✅ **#182 → `alpha`** (#163, #167) | **GDPR scheduled-jobs engine** — token-guarded cron endpoint + jobs wiring the existing `data_rights.php` deletion/anonymisation + retention sweeps. **Ships fully inert** (all settings OFF, deletion dry-run); 45 unit + 17 integration tests. Activation is an owner action (D1). |
+| ✅ **Issue hygiene** | Closed #159/#163/#164/#166/#167/#175; filed #178 (scheduling), #180 (pricing engine), #183 (MariaDB portability). Full open+closed backlog review (Fable) — **0 wrongly-closed**. |
 
 ---
 
 ## 📌 Open backlog highlights (authoritative live list in `HANDOFF.md` + the tracker)
 
 **Launch-gating, still open:**
-- 🔴 **#163** — GDPR account-deletion requests never executed (blocked on D1; code buildable now via the token-guarded endpoint).
-- 🔴 **#167** — published data-retention periods not enforced (blocked on D1).
+- 🔴 **#183** — `036_pricing_engine.sql` STORED generated column may fail to import on **MariaDB** (our production host); CI only tests `mysql:8`. Fix = explicit `CAST` + add MariaDB to CI. **Recommended next task** (also confirm target DB: MariaDB vs MySQL).
 - 🟠 **#165** — individually-registered users (`[default]` org) get **no analytics** (per-user scoping fix).
 - 🟠 **#158** — SFTP deploy: remaining owner decisions (base path, branch gate, re-arm after dry-run).
+
+**Now DONE (activation is owner-gated, not code):**
+- ✅ **#163 / #167** — GDPR deletion + retention engine built & merged (#182), shipped **disabled**. Enable per D1/#178.
 
 **Quality / near-launch:** #153 (phpcs conformance + flip the gate; ~9.3k auto-fixable), #151 (UTM analytics dimension), #152 (xlsx export), #127 (orgHandle-vs-surrogate-FK design), #71 (9 locales).
 
 **Post-launch (correctly open):** #51–#56 Phase-9 advanced redirects; #34–#37 SIGNula auth; #57–#60 billing; #139–#144 enhancements (need owner triage).
 
-**Fixed & closed this session:** #159, #162 (verified), #164, #166, #175.
+**Fixed & closed this session:** #159, #162 (verified), #163, #164, #166, #167, #175.
 
 ---
 


### PR DESCRIPTION
Docs-only. Updates `HANDOFF.md` + `PRE_LAUNCH_CHECKLIST.md` to record the GDPR scheduled-jobs engine (#182, closing #163/#167, shipped disabled) and to flag the MariaDB portability finding **#183** as the recommended next task. Markdown only.

---
_Generated by [Claude Code](https://claude.ai/code/session_019v28sGYqnGeBSPNbGgVwgJ)_