### PR TITLE
chore(gitignore): ignore transient agent worktrees (.claude/worktrees/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,9 @@ core
 # `.claude/settings.local.json` holds per-machine/per-user Claude Code settings
 # (permissions, local overrides). The shared `.claude/settings.json` IS tracked.
 .claude/settings.local.json
+# `.claude/worktrees/` holds transient, isolated git worktrees created for
+# parallel agent tasks; git auto-removes them, they must never be committed.
+.claude/worktrees/
 *.vsix
 
 # Visual Studio


### PR DESCRIPTION
Parallel agent tasks run in isolated git worktrees under `.claude/worktrees/`; git auto-removes them and they must never be committed. Adds the ignore (mirrors the existing `.claude/settings.local.json` ignore). One-line `.gitignore` change.

---
_Generated by [Claude Code](https://claude.ai/code/session_019v28sGYqnGeBSPNbGgVwgJ)_