### PR TITLE
fix(#183): pricing-engine generated column imports on MariaDB + test both engines in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,11 +198,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
+        # #183: import + test on BOTH engines. MySQL 8 is the CI baseline;
+        # MariaDB is what Dreamhost (production) runs, so schema-portability
+        # regressions surface here instead of at install time. The MariaDB
+        # image accepts the MYSQL_* env vars + the mysqladmin/mysql clients.
+        db-image: ["mysql:8", "mariadb:11"]
     runs-on: ${{ matrix.os }}
 
     services:
       mysql:
-        image: "mysql:8"
+        image: "${{ matrix.db-image }}"
         env:
           MYSQL_ROOT_PASSWORD: "g2ml_ci_root_password"
           MYSQL_DATABASE: "mwtools_Go2MyLink"

--- a/web/_sql/migrations/020_pricing_engine.sql
+++ b/web/_sql/migrations/020_pricing_engine.sql
@@ -246,8 +246,10 @@ CREATE TABLE IF NOT EXISTS `tblTierFeatures` (
         COMMENT 'When this entitlement value starts applying (NULL = since forever)',
     `effectiveUntil`        DATETIME            DEFAULT NULL
         COMMENT 'When this entitlement value stops applying (NULL = open-ended)',
+    -- #183: explicit CAST(... AS DATETIME) for MariaDB compatibility (see the
+    -- matching note in web/_sql/schema/036_pricing_engine.sql).
     `effectiveFromKey`      DATETIME
-                            GENERATED ALWAYS AS (COALESCE(`effectiveFrom`, '1000-01-01 00:00:00')) STORED
+                            GENERATED ALWAYS AS (COALESCE(`effectiveFrom`, CAST('1000-01-01 00:00:00' AS DATETIME))) STORED
         COMMENT 'NULL-collapsed mirror of effectiveFrom so undated rows dedupe in UQ_tierfeature (settings #150 idiom)',
     `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `updatedAt`             DATETIME            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/web/_sql/schema/036_pricing_engine.sql
+++ b/web/_sql/schema/036_pricing_engine.sql
@@ -484,8 +484,13 @@ CREATE TABLE IF NOT EXISTS `tblTierFeatures` (
     -- so without this two undated rows for the same (tier, feature) pair would
     -- both insert. '1000-01-01' is a legal DATETIME under the project's
     -- NO_ZERO_DATE sql_mode (000_create_database.sql) — NOT a zero-date.
+    -- #183: the sentinel is wrapped in an explicit CAST(... AS DATETIME) so the
+    -- STORED expression is deterministic on MariaDB too. MariaDB rejects the
+    -- implicit string->DATETIME coercion inside a PERSISTENT/STORED generated
+    -- column that MySQL 8 silently accepts (Dreamhost runs MariaDB); the CAST
+    -- imports cleanly on both. CI now exercises the schema on both engines.
     `effectiveFromKey`      DATETIME
-                            GENERATED ALWAYS AS (COALESCE(`effectiveFrom`, '1000-01-01 00:00:00')) STORED
+                            GENERATED ALWAYS AS (COALESCE(`effectiveFrom`, CAST('1000-01-01 00:00:00' AS DATETIME))) STORED
         COMMENT 'NULL-collapsed mirror of effectiveFrom so undated rows dedupe in UQ_tierfeature (settings #150 idiom)',
 
     `createdAt`             DATETIME            NOT NULL DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
## 📋 Summary

Closes **#183**. `036_pricing_engine.sql` (and its deployed-DB twin `migrations/020_pricing_engine.sql`) defined `effectiveFromKey` as a **STORED generated column** using `COALESCE(effectiveFrom, '1000-01-01 00:00:00')`. MySQL 8 accepts the implicit string→DATETIME coercion; **MariaDB rejects it** in a PERSISTENT/STORED generated column as non-deterministic. Dreamhost (production) runs MariaDB and the installer imports every `schema/*.sql`, so this could **abort a fresh install** — and CI only tested `mysql:8`, so it went unseen.

## 🔄 Changes

- Wrap the sentinel in an explicit **`CAST('1000-01-01 00:00:00' AS DATETIME)`** (deterministic, imports cleanly on **both** engines) — in `036` and `migrations/020`.
- **Add MariaDB (`mariadb:11`) to the `tests-integration` CI matrix** alongside `mysql:8`, so this class of tier/engine drift is caught automatically from now on. (Still advisory / non-blocking.)

## ✅ Testing

- `php tests/run.php` → **594 passed / 0 failed** (unaffected).
- The new **`Tests (Integration) (ubuntu-latest, mariadb:11)`** check imports the full schema on MariaDB — that's the reproducible validation this PR is really about.

## 🔗 Related

Closes #183. Follows the pricing engine #179/#180.

---

> Tracked on the [Go2My.Link Project Board](https://github.com/orgs/MWBMPartners/projects/4)

---
_Generated by [Claude Code](https://claude.ai/code/session_019v28sGYqnGeBSPNbGgVwgJ)_