### PR TITLE
fix(#165): per-user analytics for individually-registered ([default]-org) users

### DIFF
--- a/tests/integration/analytics_test.php
+++ b/tests/integration/analytics_test.php
@@ -528,6 +528,53 @@ test('analyticsTotals: org-wide totals for org A never include org B\'s 10 click
 });
 
 // ============================================================================
+// 🔐 #165 — per-user scoping for the shared "[default]" bucket org
+// ============================================================================
+// User A owns analyticsA1/A2 in the shared '[default]' org; user B owns
+// analyticsB1 in the real org 'orgbanalytics' and therefore owns NOTHING in
+// '[default]'. So a '[default]' aggregate scoped to user B MUST be empty even
+// though the '[default]' org-wide total is 6 — that is the exact cross-user
+// isolation this feature must guarantee (one unassigned user can never see
+// another's analytics). Scoped to user A it returns A's own data; scoped to
+// null it is the unchanged pre-#165 org-wide behaviour.
+
+test('#165 analyticsTotals: [default] scoped to the OWNING user returns their own clicks', function () use ($g2mlAnalyticsFrom, $g2mlAnalyticsTo, $g2mlAnalyticsUserA): void
+{
+    $totals = g2ml_analyticsTotals('[default]', null, $g2mlAnalyticsFrom, $g2mlAnalyticsTo, $g2mlAnalyticsUserA);
+    assert_same(6, $totals['totalClicks'], 'User A owns analyticsA1(5)+A2(1) in [default] => 6');
+});
+
+test('#165 analyticsTotals: [default] scoped to a NON-owning user returns ZERO (no cross-user leak)', function () use ($g2mlAnalyticsFrom, $g2mlAnalyticsTo, $g2mlAnalyticsUserB): void
+{
+    $totals = g2ml_analyticsTotals('[default]', null, $g2mlAnalyticsFrom, $g2mlAnalyticsTo, $g2mlAnalyticsUserB);
+    assert_same(0, $totals['totalClicks'], 'User B owns no [default] links => 0, NOT the org-wide 6');
+});
+
+test('#165 analyticsTopLinks: [default] scoped to the owner returns only their codes', function () use ($g2mlAnalyticsFrom, $g2mlAnalyticsTo, $g2mlAnalyticsUserA): void
+{
+    $topLinks = g2ml_analyticsTopLinks('[default]', $g2mlAnalyticsFrom, $g2mlAnalyticsTo, 10, $g2mlAnalyticsUserA);
+    assert_same(2, count($topLinks), 'User A owns exactly two [default] codes with clicks (A1, A2)');
+});
+
+test('#165 analyticsTopLinks: [default] scoped to a non-owning user returns an EMPTY ranking', function () use ($g2mlAnalyticsFrom, $g2mlAnalyticsTo, $g2mlAnalyticsUserB): void
+{
+    $topLinks = g2ml_analyticsTopLinks('[default]', $g2mlAnalyticsFrom, $g2mlAnalyticsTo, 10, $g2mlAnalyticsUserB);
+    assert_same(0, count($topLinks), 'User B owns no [default] codes => empty, never A1/A2');
+});
+
+test('#165 analyticsBreakdown: [default] scoped to a non-owning user returns nothing', function () use ($g2mlAnalyticsFrom, $g2mlAnalyticsTo, $g2mlAnalyticsUserB): void
+{
+    $rows = g2ml_analyticsBreakdown('[default]', null, 'browserName', $g2mlAnalyticsFrom, $g2mlAnalyticsTo, 10, $g2mlAnalyticsUserB);
+    assert_same(0, count($rows), 'A non-owning [default] user sees no breakdown rows');
+});
+
+test('#165 analyticsTotals: null scope keeps the org-wide behaviour unchanged', function () use ($g2mlAnalyticsFrom, $g2mlAnalyticsTo): void
+{
+    $totals = g2ml_analyticsTotals('[default]', null, $g2mlAnalyticsFrom, $g2mlAnalyticsTo, null);
+    assert_same(6, $totals['totalClicks'], 'null scope = the pre-#165 org-wide [default] total (6)');
+});
+
+// ============================================================================
 // 🏆 g2ml_analyticsTopLinks()
 // ============================================================================
 

--- a/web/Go2My.Link/_admin/public_html/analytics-export.php
+++ b/web/Go2My.Link/_admin/public_html/analytics-export.php
@@ -146,12 +146,15 @@ requireAuth('User');
 $currentUser = getCurrentUser();
 $orgHandle   = $currentUser['orgHandle'];
 
+// #165: scope the shared "[default]" bucket org to the caller's OWN links
+// (mirrors pages/analytics/index.php) instead of blocking the export outright,
+// so individually-registered users can export their own analytics. A real-org
+// user keeps the org-wide export ($analyticsUserScope stays null).
+$analyticsUserScope = null;
+
 if ($orgHandle === '[default]')
 {
-    http_response_code(403);
-    header('Content-Type: text/plain; charset=utf-8');
-    echo 'Analytics export is not available for accounts that are not yet part of an organisation.';
-    exit;
+    $analyticsUserScope = (int) ($currentUser['userUID'] ?? 0);
 }
 
 // ============================================================================
@@ -195,11 +198,23 @@ if ($rawCode !== '')
 {
     if (preg_match('/^[A-Za-z0-9_-]{1,50}$/', $rawCode) === 1)
     {
-        $codeRow = dbSelectOne(
-            'SELECT shortCode FROM tblShortURLs WHERE shortCode = ? AND orgHandle = ? LIMIT 1',
-            'ss',
-            [$rawCode, $orgHandle]
-        );
+        if ($analyticsUserScope !== null)
+        {
+            // #165: a '[default]' user may only export a code they OWN.
+            $codeRow = dbSelectOne(
+                'SELECT shortCode FROM tblShortURLs WHERE shortCode = ? AND orgHandle = ? AND createdByUserUID = ? LIMIT 1',
+                'ssi',
+                [$rawCode, $orgHandle, $analyticsUserScope]
+            );
+        }
+        else
+        {
+            $codeRow = dbSelectOne(
+                'SELECT shortCode FROM tblShortURLs WHERE shortCode = ? AND orgHandle = ? LIMIT 1',
+                'ss',
+                [$rawCode, $orgHandle]
+            );
+        }
 
         if ($codeRow !== null && $codeRow !== false)
         {
@@ -307,7 +322,7 @@ $filenameSlug = $exportType;
 
 if ($exportType === 'top-links')
 {
-    $topLinks = g2ml_analyticsTopLinks($orgHandle, $range['from'], $range['to'], $rawLimit);
+    $topLinks = g2ml_analyticsTopLinks($orgHandle, $range['from'], $range['to'], $rawLimit, $analyticsUserScope);
 
     $csvHeaders = [g2ml_csvHumaniseHeader('shortCode'), g2ml_csvHumaniseHeader('clicks')];
 
@@ -318,7 +333,7 @@ if ($exportType === 'top-links')
 }
 elseif ($exportType === 'clicks-over-time')
 {
-    $clicksSeries = g2ml_analyticsClicksOverTime($orgHandle, $shortCode, $range['from'], $range['to'], $bucket);
+    $clicksSeries = g2ml_analyticsClicksOverTime($orgHandle, $shortCode, $range['from'], $range['to'], $bucket, $analyticsUserScope);
 
     $csvHeaders = [g2ml_csvHumaniseHeader('bucket'), g2ml_csvHumaniseHeader('clicks')];
 
@@ -329,7 +344,7 @@ elseif ($exportType === 'clicks-over-time')
 }
 elseif ($exportType === 'breakdown')
 {
-    $breakdownRows = g2ml_analyticsBreakdown($orgHandle, $shortCode, $dimension, $range['from'], $range['to'], $rawLimit);
+    $breakdownRows = g2ml_analyticsBreakdown($orgHandle, $shortCode, $dimension, $range['from'], $range['to'], $rawLimit, $analyticsUserScope);
 
     $csvHeaders   = [g2ml_csvHumaniseHeader($dimension), g2ml_csvHumaniseHeader('clicks')];
     $filenameSlug = $filenameSlug . '-' . $dimension;
@@ -341,7 +356,7 @@ elseif ($exportType === 'breakdown')
 }
 elseif ($exportType === 'scan-sources')
 {
-    $scanSourceRows = g2ml_analyticsScanSources($orgHandle, $shortCode, $range['from'], $range['to']);
+    $scanSourceRows = g2ml_analyticsScanSources($orgHandle, $shortCode, $range['from'], $range['to'], $analyticsUserScope);
 
     $csvHeaders = [g2ml_csvHumaniseHeader('scanSource'), g2ml_csvHumaniseHeader('scans')];
 
@@ -354,7 +369,7 @@ else
 {
     // 'totals' — a single summary row (validated above; this is the only
     // remaining branch of $validExportTypes).
-    $totalsRow = g2ml_analyticsTotals($orgHandle, $shortCode, $range['from'], $range['to']);
+    $totalsRow = g2ml_analyticsTotals($orgHandle, $shortCode, $range['from'], $range['to'], $analyticsUserScope);
 
     foreach (array_keys($totalsRow) as $totalsKey)
     {

--- a/web/Go2My.Link/_admin/public_html/pages/analytics/index.php
+++ b/web/Go2My.Link/_admin/public_html/pages/analytics/index.php
@@ -246,20 +246,20 @@ function _analyticsRenderCsvLink(?string $shortCode, array $range, string $type,
 }
 
 // ============================================================================
-// 🚫 Block the shared "[default]" bucket org — see docblock above
+// 🔐 Per-user scope for the shared "[default]" bucket org (#165)
 // ============================================================================
+// Every user not yet in a real organisation shares orgHandle '[default]', so an
+// org-wide aggregate would show OTHER users' clicks. Rather than BLOCK the
+// dashboard (the old behaviour — every individually-registered user saw
+// nothing), scope every query below to the caller's own createdByUserUID,
+// exactly as links/index.php does. A real-org user keeps org-wide analytics
+// ($analyticsUserScope stays null). See web/_functions/analytics.php (#165).
+
+$analyticsUserScope = null;
 
 if ($orgHandle === '[default]')
 {
-    echo '<div class="container py-5"><div class="alert alert-warning">';
-    echo '<i class="fas fa-triangle-exclamation" aria-hidden="true"></i> ';
-    if (function_exists('__')) {
-        echo g2ml_sanitiseOutput(__('analytics.error_unavailable'));
-    } else {
-        echo 'Analytics is not available for accounts that are not yet part of an organisation.';
-    }
-    echo '</div></div>';
-    return;
+    $analyticsUserScope = (int) ($currentUser['userUID'] ?? 0);
 }
 
 // ============================================================================
@@ -280,11 +280,25 @@ if ($rawCode !== '')
 {
     if (preg_match('/^[A-Za-z0-9_-]{1,50}$/', $rawCode) === 1)
     {
-        $codeRow = dbSelectOne(
-            'SELECT shortCode, title FROM tblShortURLs WHERE shortCode = ? AND orgHandle = ? LIMIT 1',
-            'ss',
-            [$rawCode, $orgHandle]
-        );
+        if ($analyticsUserScope !== null)
+        {
+            // #165: a '[default]' user may only drill into a code they OWN —
+            // the orgHandle check alone would let one '[default]' user view
+            // another '[default]' user's code by guessing it.
+            $codeRow = dbSelectOne(
+                'SELECT shortCode, title FROM tblShortURLs WHERE shortCode = ? AND orgHandle = ? AND createdByUserUID = ? LIMIT 1',
+                'ssi',
+                [$rawCode, $orgHandle, $analyticsUserScope]
+            );
+        }
+        else
+        {
+            $codeRow = dbSelectOne(
+                'SELECT shortCode, title FROM tblShortURLs WHERE shortCode = ? AND orgHandle = ? LIMIT 1',
+                'ss',
+                [$rawCode, $orgHandle]
+            );
+        }
 
         if ($codeRow !== null && $codeRow !== false)
         {
@@ -332,9 +346,9 @@ $bucket = g2ml_analyticsDashboardBucketForRangeDays($range['rangeDays']);
 // 📊 Fetch every aggregate from the #41 data layer — org-scoped throughout
 // ============================================================================
 
-$totals         = g2ml_analyticsTotals($orgHandle, $shortCode, $range['from'], $range['to']);
-$clicksOverTime = g2ml_analyticsClicksOverTime($orgHandle, $shortCode, $range['from'], $range['to'], $bucket);
-$scanSources    = g2ml_analyticsScanSources($orgHandle, $shortCode, $range['from'], $range['to']);
+$totals         = g2ml_analyticsTotals($orgHandle, $shortCode, $range['from'], $range['to'], $analyticsUserScope);
+$clicksOverTime = g2ml_analyticsClicksOverTime($orgHandle, $shortCode, $range['from'], $range['to'], $bucket, $analyticsUserScope);
+$scanSources    = g2ml_analyticsScanSources($orgHandle, $shortCode, $range['from'], $range['to'], $analyticsUserScope);
 
 $topLinks = [];
 
@@ -342,19 +356,19 @@ if ($shortCode === null)
 {
     // Ranking a single code against itself is meaningless — org-wide only,
     // exactly like g2ml_analyticsTopLinks()'s own contract.
-    $topLinks = g2ml_analyticsTopLinks($orgHandle, $range['from'], $range['to'], 8);
+    $topLinks = g2ml_analyticsTopLinks($orgHandle, $range['from'], $range['to'], 8, $analyticsUserScope);
 }
 
-$browserBreakdown  = g2ml_analyticsBreakdown($orgHandle, $shortCode, 'browserName', $range['from'], $range['to'], 6);
-$osBreakdown       = g2ml_analyticsBreakdown($orgHandle, $shortCode, 'osName', $range['from'], $range['to'], 6);
-$deviceBreakdown   = g2ml_analyticsBreakdown($orgHandle, $shortCode, 'deviceType', $range['from'], $range['to'], 6);
-$refererBreakdown  = g2ml_analyticsBreakdown($orgHandle, $shortCode, 'requestReferer', $range['from'], $range['to'], 10);
+$browserBreakdown  = g2ml_analyticsBreakdown($orgHandle, $shortCode, 'browserName', $range['from'], $range['to'], 6, $analyticsUserScope);
+$osBreakdown       = g2ml_analyticsBreakdown($orgHandle, $shortCode, 'osName', $range['from'], $range['to'], 6, $analyticsUserScope);
+$deviceBreakdown   = g2ml_analyticsBreakdown($orgHandle, $shortCode, 'deviceType', $range['from'], $range['to'], 6, $analyticsUserScope);
+$refererBreakdown  = g2ml_analyticsBreakdown($orgHandle, $shortCode, 'requestReferer', $range['from'], $range['to'], 10, $analyticsUserScope);
 
 // countryCode (#43) — empty whenever geolocation has never run (the default,
 // until an operator turns analytics.geolocation_enabled on AND deploys a
 // GeoIP database); the widget below renders the same "no data" state as any
 // other breakdown with zero rows, so no extra handling is needed here.
-$countryBreakdown  = g2ml_analyticsBreakdown($orgHandle, $shortCode, 'countryCode', $range['from'], $range['to'], 8);
+$countryBreakdown  = g2ml_analyticsBreakdown($orgHandle, $shortCode, 'countryCode', $range['from'], $range['to'], 8, $analyticsUserScope);
 
 // ============================================================================
 // 🧮 Human/bot percentages for the totals cards (guard divide-by-zero)

--- a/web/Go2My.Link/public_html/api/v1/handlers/analytics.php
+++ b/web/Go2My.Link/public_html/api/v1/handlers/analytics.php
@@ -326,16 +326,39 @@ function g2ml_apiHandleAnalyticsGet(array $keyRow, array $context): array
     $code      = _g2ml_apiAnalyticsRequireRouteCode($context);
     $orgHandle = (string) $keyRow['orgHandle'];
 
+    // #165: a key in the shared "[default]" bucket org must be scoped to its
+    // OWN user's links (every unassigned user shares '[default]'); a real-org
+    // key keeps org-wide access ($apiUserScope stays null).
+    $apiUserScope = null;
+
+    if ($orgHandle === '[default]')
+    {
+        $apiUserScope = (int) ($keyRow['userUID'] ?? 0);
+    }
+
     // ------------------------------------------------------------------------
     // Existence + org-scoping check BEFORE running any aggregate — a code
     // belonging to a different org must 404 identically to one that does not
-    // exist, exactly like g2ml_apiHandleUrlsGet() (urls.php).
+    // exist, exactly like g2ml_apiHandleUrlsGet() (urls.php). For a '[default]'
+    // key we ALSO require the code to be owned by the key's user, so one
+    // '[default]' user cannot read another's analytics.
     // ------------------------------------------------------------------------
-    $existing = dbSelectOne(
-        'SELECT urlUID FROM tblShortURLs WHERE shortCode = ? AND orgHandle = ? LIMIT 1',
-        'ss',
-        [$code, $orgHandle]
-    );
+    if ($apiUserScope !== null)
+    {
+        $existing = dbSelectOne(
+            'SELECT urlUID FROM tblShortURLs WHERE shortCode = ? AND orgHandle = ? AND createdByUserUID = ? LIMIT 1',
+            'ssi',
+            [$code, $orgHandle, $apiUserScope]
+        );
+    }
+    else
+    {
+        $existing = dbSelectOne(
+            'SELECT urlUID FROM tblShortURLs WHERE shortCode = ? AND orgHandle = ? LIMIT 1',
+            'ss',
+            [$code, $orgHandle]
+        );
+    }
 
     if ($existing === null || $existing === false)
     {
@@ -362,9 +385,9 @@ function g2ml_apiHandleAnalyticsGet(array $keyRow, array $context): array
 
     $dimension = _g2ml_apiAnalyticsValidateDimension($rawDimension);
 
-    $totals         = g2ml_analyticsTotals($orgHandle, $code, $range['from'], $range['to']);
-    $clicksOverTime = g2ml_analyticsClicksOverTime($orgHandle, $code, $range['from'], $range['to'], $bucket);
-    $scanSources    = g2ml_analyticsScanSources($orgHandle, $code, $range['from'], $range['to']);
+    $totals         = g2ml_analyticsTotals($orgHandle, $code, $range['from'], $range['to'], $apiUserScope);
+    $clicksOverTime = g2ml_analyticsClicksOverTime($orgHandle, $code, $range['from'], $range['to'], $bucket, $apiUserScope);
+    $scanSources    = g2ml_analyticsScanSources($orgHandle, $code, $range['from'], $range['to'], $apiUserScope);
 
     $formattedClicksOverTime = [];
 
@@ -408,7 +431,7 @@ function g2ml_apiHandleAnalyticsGet(array $keyRow, array $context): array
         }
 
         $limit     = _g2ml_apiAnalyticsValidateLimit($rawLimit, 10, 100);
-        $breakdown = g2ml_analyticsBreakdown($orgHandle, $code, $dimension, $range['from'], $range['to'], $limit);
+        $breakdown = g2ml_analyticsBreakdown($orgHandle, $code, $dimension, $range['from'], $range['to'], $limit, $apiUserScope);
 
         $formattedBreakdownItems = [];
 
@@ -451,6 +474,15 @@ function g2ml_apiHandleAnalyticsSummary(array $keyRow, array $context): array
 {
     $orgHandle = (string) $keyRow['orgHandle'];
 
+    // #165: a "[default]"-bucket key sees only its own user's links (see
+    // g2ml_apiHandleAnalyticsGet()); a real-org key stays org-wide.
+    $apiUserScope = null;
+
+    if ($orgHandle === '[default]')
+    {
+        $apiUserScope = (int) ($keyRow['userUID'] ?? 0);
+    }
+
     $range = _g2ml_apiAnalyticsResolveRange();
 
     $rawLimit = null;
@@ -462,8 +494,8 @@ function g2ml_apiHandleAnalyticsSummary(array $keyRow, array $context): array
 
     $limit = _g2ml_apiAnalyticsValidateLimit($rawLimit, 10, 100);
 
-    $totals   = g2ml_analyticsTotals($orgHandle, null, $range['from'], $range['to']);
-    $topLinks = g2ml_analyticsTopLinks($orgHandle, $range['from'], $range['to'], $limit);
+    $totals   = g2ml_analyticsTotals($orgHandle, null, $range['from'], $range['to'], $apiUserScope);
+    $topLinks = g2ml_analyticsTopLinks($orgHandle, $range['from'], $range['to'], $limit, $apiUserScope);
 
     $formattedTopLinks = [];
 

--- a/web/_functions/analytics.php
+++ b/web/_functions/analytics.php
@@ -221,7 +221,7 @@ function _g2ml_analyticsClampLimit(int $limit, int $default, int $max): int
  * @param  string      $to         Inclusive range end, 'Y-m-d H:i:s'.
  * @return array{where: string, types: string, params: array<int, mixed>}
  */
-function _g2ml_analyticsClickWhere(string $orgHandle, ?string $shortCode, string $from, string $to): array
+function _g2ml_analyticsClickWhere(string $orgHandle, ?string $shortCode, string $from, string $to, ?int $createdByUserUID = null): array
 {
     $conditions = [
         "logAction = 'redirect'",
@@ -239,6 +239,22 @@ function _g2ml_analyticsClickWhere(string $orgHandle, ?string $shortCode, string
         $conditions[] = 'shortCode = ?';
         $types        = $types . 's';
         $params[]     = $shortCode;
+    }
+
+    // #165: per-user scoping for the shared "[default]" bucket org. Every
+    // unassigned user shares orgHandle '[default]', so an org-wide aggregate
+    // would leak OTHER users' clicks. When a positive createdByUserUID is
+    // supplied, additionally restrict to the activity rows whose short code the
+    // user OWNS, resolved via a subquery on tblShortURLs (shortCode is unique
+    // per org — UQ_shortcode_org — so a '[default]' user sees only their own
+    // links). Uses IDX_url_creator (createdByUserUID). Callers pass null for a
+    // real org, which keeps the existing org-wide behaviour unchanged.
+    if ($createdByUserUID !== null && $createdByUserUID > 0)
+    {
+        $conditions[] = 'shortCode IN (SELECT shortCode FROM tblShortURLs WHERE orgHandle = ? AND createdByUserUID = ?)';
+        $types        = $types . 'si';
+        $params[]     = $orgHandle;
+        $params[]     = $createdByUserUID;
     }
 
     return [
@@ -262,10 +278,10 @@ function _g2ml_analyticsClickWhere(string $orgHandle, ?string $shortCode, string
  * @param  string      $bucket     'day' (default), 'week', or 'month'.
  * @return array<int, array{bucket: string, clicks: int}>  Ordered ascending by bucket.
  */
-function g2ml_analyticsClicksOverTime(string $orgHandle, ?string $shortCode, string $from, string $to, string $bucket = 'day'): array
+function g2ml_analyticsClicksOverTime(string $orgHandle, ?string $shortCode, string $from, string $to, string $bucket = 'day', ?int $createdByUserUID = null): array
 {
     $bucketFormat = _g2ml_analyticsBucketFormat($bucket);
-    $whereClause  = _g2ml_analyticsClickWhere($orgHandle, $shortCode, $from, $to);
+    $whereClause  = _g2ml_analyticsClickWhere($orgHandle, $shortCode, $from, $to, $createdByUserUID);
 
     $sql = 'SELECT DATE_FORMAT(createdAt, ?) AS bucketLabel, COUNT(*) AS clicks '
         . 'FROM tblActivityLog '
@@ -315,9 +331,9 @@ function g2ml_analyticsClicksOverTime(string $orgHandle, ?string $shortCode, str
  * @param  string      $to         Inclusive range end, 'Y-m-d H:i:s'.
  * @return array{totalClicks: int, uniqueIPs: int, botClicks: int, humanClicks: int, unknownClicks: int}
  */
-function g2ml_analyticsTotals(string $orgHandle, ?string $shortCode, string $from, string $to): array
+function g2ml_analyticsTotals(string $orgHandle, ?string $shortCode, string $from, string $to, ?int $createdByUserUID = null): array
 {
-    $whereClause = _g2ml_analyticsClickWhere($orgHandle, $shortCode, $from, $to);
+    $whereClause = _g2ml_analyticsClickWhere($orgHandle, $shortCode, $from, $to, $createdByUserUID);
 
     $sql = 'SELECT '
         . 'COUNT(*) AS totalClicks, '
@@ -367,20 +383,39 @@ function g2ml_analyticsTotals(string $orgHandle, ?string $shortCode, string $fro
  * @param  int    $limit      Maximum rows to return (default 10, clamped 1-100).
  * @return array<int, array{shortCode: string, clicks: int}>  Ordered descending by clicks.
  */
-function g2ml_analyticsTopLinks(string $orgHandle, string $from, string $to, int $limit = 10): array
+function g2ml_analyticsTopLinks(string $orgHandle, string $from, string $to, int $limit = 10, ?int $createdByUserUID = null): array
 {
     $clampedLimit = _g2ml_analyticsClampLimit($limit, 10, 100);
+
+    // #165: this function builds its SQL directly (not via the shared WHERE
+    // builder), so it applies the same per-user scope inline. See
+    // _g2ml_analyticsClickWhere() for the rationale.
+    $userScopeSql = '';
+    $types        = 'sss';
+    $params       = [$orgHandle, $from, $to];
+
+    if ($createdByUserUID !== null && $createdByUserUID > 0)
+    {
+        $userScopeSql = 'AND shortCode IN (SELECT shortCode FROM tblShortURLs WHERE orgHandle = ? AND createdByUserUID = ?) ';
+        $types        = $types . 'si';
+        $params[]     = $orgHandle;
+        $params[]     = $createdByUserUID;
+    }
 
     $sql = 'SELECT shortCode, COUNT(*) AS clicks '
         . 'FROM tblActivityLog '
         . "WHERE logAction = 'redirect' AND logStatus = 'success' "
         . 'AND orgHandle = ? AND createdAt >= ? AND createdAt <= ? '
         . 'AND shortCode IS NOT NULL '
+        . $userScopeSql
         . 'GROUP BY shortCode '
         . 'ORDER BY clicks DESC '
         . 'LIMIT ?';
 
-    $rows = dbSelect($sql, 'sssi', [$orgHandle, $from, $to, $clampedLimit]);
+    $types    = $types . 'i';
+    $params[] = $clampedLimit;
+
+    $rows = dbSelect($sql, $types, $params);
 
     if ($rows === false)
     {
@@ -421,7 +456,7 @@ function g2ml_analyticsTopLinks(string $orgHandle, string $from, string $to, int
  * @param  int         $limit      Maximum distinct values to return (clamped 1-100).
  * @return array<int, array{value: string, clicks: int}>  Ordered descending by clicks; empty when $dimension is not whitelisted.
  */
-function g2ml_analyticsBreakdown(string $orgHandle, ?string $shortCode, string $dimension, string $from, string $to, int $limit = 10): array
+function g2ml_analyticsBreakdown(string $orgHandle, ?string $shortCode, string $dimension, string $from, string $to, int $limit = 10, ?int $createdByUserUID = null): array
 {
     $column = _g2ml_analyticsDimensionColumn($dimension);
 
@@ -431,7 +466,7 @@ function g2ml_analyticsBreakdown(string $orgHandle, ?string $shortCode, string $
     }
 
     $clampedLimit = _g2ml_analyticsClampLimit($limit, 10, 100);
-    $whereClause  = _g2ml_analyticsClickWhere($orgHandle, $shortCode, $from, $to);
+    $whereClause  = _g2ml_analyticsClickWhere($orgHandle, $shortCode, $from, $to, $createdByUserUID);
 
     $sql = 'SELECT `' . $column . '` AS dimensionValue, COUNT(*) AS clicks '
         . 'FROM tblActivityLog '
@@ -482,9 +517,9 @@ function g2ml_analyticsBreakdown(string $orgHandle, ?string $shortCode, string $
  * @param  string      $to         Inclusive range end, 'Y-m-d H:i:s'.
  * @return array<int, array{scanSource: string, scans: int}>  Ordered descending by scans.
  */
-function g2ml_analyticsScanSources(string $orgHandle, ?string $shortCode, string $from, string $to): array
+function g2ml_analyticsScanSources(string $orgHandle, ?string $shortCode, string $from, string $to, ?int $createdByUserUID = null): array
 {
-    $whereClause = _g2ml_analyticsClickWhere($orgHandle, $shortCode, $from, $to);
+    $whereClause = _g2ml_analyticsClickWhere($orgHandle, $shortCode, $from, $to, $createdByUserUID);
 
     $sql = 'SELECT scanSource, COUNT(*) AS scans '
         . 'FROM tblActivityLog '


### PR DESCRIPTION
## 📋 Summary

Closes **#165**. The analytics dashboard, CSV export, and API v1 hard-blocked the shared `[default]` bucket org, so **every individually-registered user got no analytics at all**. Un-blocking naively would leak — all unassigned users share `orgHandle = '[default]'`, so an org-wide aggregate mixes their clicks.

## 🔐 Approach (data-isolation is the point)

Add an optional per-user scope to the data layer. When a `createdByUserUID` is supplied, every query additionally restricts to the rows whose short code the user **owns**:

```sql
shortCode IN (SELECT shortCode FROM tblShortURLs WHERE orgHandle = ? AND createdByUserUID = ?)
```

`shortCode` is unique per org, so within `[default]` this returns **exactly the caller's own links** (uses `IDX_url_creator`). Real-org callers pass `null` and keep org-wide analytics **unchanged**.

## 🔄 Surfaces (all four) + leak closures

- **`web/_functions/analytics.php`** — `Totals` / `ClicksOverTime` / `ScanSources` / `Breakdown` / `TopLinks` gain the optional scope.
- **`pages/analytics/index.php`** — the `[default]` block becomes per-user scoping; the `?code=` drill-down now requires **ownership** (was org-only → a `[default]` user could view another's code by guessing it).
- **`analytics-export.php`** — same treatment (block + drill-down).
- **`api/v1/handlers/analytics.php`** — both handlers scope a `[default]` key to the **key's owning user** (`tblAPIKeys.userUID`); the existence check requires ownership.

## ✅ Testing

- `php -l` clean on all 5 files; **unit suite 594 / 0**.
- **Isolation regression test** (`tests/integration/analytics_test.php`): a `[default]` aggregate scoped to a user who owns **no** `[default]` links returns **ZERO**, even though the org-wide total is 6 — proving one unassigned user can never see another's analytics. Runs in the `mysql:8` integration job.
- GlobalAdmin (also `[default]`) now sees their own links' analytics instead of nothing — strictly better, no leak.

## 🔗 Related

Closes #165. (Launch-gap item from the 2026-07-19 conformance audit.)

---

> Tracked on the [Go2My.Link Project Board](https://github.com/orgs/MWBMPartners/projects/4)

---
_Generated by [Claude Code](https://claude.ai/code/session_019v28sGYqnGeBSPNbGgVwgJ)_