### PR TITLE
ci(security): four-tier Dependabot + auto-backport security fixes to alpha/beta/release-candidate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,27 +12,32 @@
 # No Composer/npm dependencies to monitor (Dreamhost has no CLI), so the only
 # ecosystem tracked is "github-actions" (the workflow action pins themselves).
 #
-# THREE-TIER COVERAGE (alpha > beta > main)
+# FOUR-TIER COVERAGE (alpha > beta > release-candidate > main)
 # -----------------------------------------------------------------------------
 # Dependabot reads this file ONLY from the default branch (main), but each
 # `updates` entry can point at a different branch via `target-branch`. We
-# therefore declare one entry per tier so version-update PRs are opened against
-# ALL THREE branches, not just main. This closes the drift/variance gap where
-# alpha and beta (which may be deployed for small-group testing) would otherwise
-# fall behind main on action pins.
+# therefore declare one entry per tier so scheduled VERSION-update PRs are
+# opened against ALL FOUR branches, not just main. This closes the drift gap
+# where alpha / beta / release-candidate (which may be deployed for testing)
+# would otherwise fall behind main on action pins.
 #
 # GROUPING: each entry groups every github-actions bump into ONE pull request
 # per branch (a "grouped update"), so a week's action bumps arrive as a single
 # mergeable PR per tier instead of several racing PRs (see #168/#169/#171).
 #
-# NOTE ON SECURITY UPDATES (owner action, tracked in the launch checklist):
-#   Dependabot *security* updates (the automatic CVE-patch PRs, distinct from
-#   these scheduled *version* updates) are a repository setting and ALWAYS
-#   target the default branch — GitHub does not let `target-branch` retarget
-#   them. To keep alpha/beta patched for security we rely on (a) these version
-#   updates, and (b) regular promotion of main's fixes down the tiers. Enabling
-#   "Dependabot security updates" + secret scanning + push protection in the
-#   repo Security settings is tracked as a pre-launch owner action.
+# SECURITY UPDATES (the important part — see .github/workflows/backport-dependencies.yml)
+#   Dependabot *security* updates (the automatic CVE-patch PRs) and GitHub's
+#   security fixes ALWAYS target the default branch (main) — `target-branch`
+#   CANNOT retarget them. So a CVE patch merged on main would leave alpha /
+#   beta / release-candidate exposed. The `backport-dependencies.yml` workflow
+#   closes this: when a dependency/security PR merges into main it automatically
+#   opens cherry-pick PRs onto every other tier. Together, these two mechanisms
+#   keep all four tiers patched — the scheduled version updates below, plus the
+#   backport of security updates.
+#
+# NOTE: `release-candidate` may not exist yet. Dependabot simply skips an entry
+# whose target-branch is absent; the entry activates the moment the branch is
+# created. (The backport workflow likewise skips a missing target branch.)
 #
 # @package    Go2My.Link
 # @author     MWBM Partners Ltd (MWservices)
@@ -86,6 +91,25 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "beta"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "infrastructure"
+    commit-message:
+      prefix: "ci"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # ---------------------------------------------------------------------------
+  # release-candidate — pre-production tier (activates once the branch exists)
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "release-candidate"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/backport-dependencies.yml
+++ b/.github/workflows/backport-dependencies.yml
@@ -1,0 +1,175 @@
+# Copyright (c) 2024–2026 MWBM Partners Ltd (MWservices).
+# All rights reserved.
+#
+# This source code is proprietary and confidential.
+# Unauthorised copying, modification, or distribution is strictly prohibited.
+
+# =============================================================================
+# Go2My.Link — Backport dependency & security fixes off the default branch
+# =============================================================================
+#
+# WHY THIS EXISTS
+#   Dependabot *security* updates (CVE auto-patches) and GitHub's own security
+#   fixes ALWAYS target the default branch (main) — `target-branch` in
+#   dependabot.yml cannot retarget them. So a security fix merged into main
+#   would leave the alpha / beta / release-candidate tiers exposed.
+#
+#   This workflow closes that gap: when a dependency/security PR is MERGED into
+#   main, it opens a cherry-pick PR of that fix onto every other tier, so the
+#   fix flows to all deployed branches instead of only production.
+#
+#   (Scheduled *version* updates are handled separately, per-branch, by
+#   .github/dependabot.yml — this workflow is specifically the SECURITY-update
+#   propagation the target-branch mechanism cannot do.)
+#
+# SAFETY
+#   - Runs ONLY for merged PRs into main carrying a dependencies/security/
+#     infrastructure label (Dependabot labels its PRs "dependencies").
+#   - Never runs any code from the merged PR — it only cherry-picks the commit
+#     and opens PRs, so `pull_request_target` is safe here.
+#   - A target branch that does not exist yet is skipped cleanly.
+#   - On a cherry-pick CONFLICT it pushes NOTHING; it opens a tracking issue so
+#     a human can backport by hand. It can never leave a branch half-modified.
+#
+# CI ON THE BACKPORT PRs (owner action)
+#   PRs opened with the default GITHUB_TOKEN do NOT trigger further workflows
+#   (GitHub's recursion guard), so their CI checks will not auto-run. To have
+#   the backport PRs run CI automatically, add a repo secret `BACKPORT_TOKEN`
+#   (a fine-grained PAT / GitHub App token with contents:write + pull-requests:
+#   write). This workflow uses it when present and falls back to GITHUB_TOKEN
+#   otherwise (PR still created; re-run its checks manually).
+#
+# @package    Go2My.Link
+# @author     MWBM Partners Ltd (MWservices)
+# @since      v1.6.0 — four-tier security coverage
+# =============================================================================
+
+name: Backport dependency & security fixes
+
+on:
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: "backport-${{ github.event.pull_request.number }}"
+  cancel-in-progress: false
+
+jobs:
+  backport:
+    name: "Backport to ${{ matrix.target }}"
+    # Only for MERGED PRs that are dependency / security related.
+    if: >-
+      github.event.pull_request.merged == true &&
+      (
+        contains(github.event.pull_request.labels.*.name, 'dependencies') ||
+        contains(github.event.pull_request.labels.*.name, 'security') ||
+        contains(github.event.pull_request.labels.*.name, 'infrastructure')
+      )
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - alpha
+          - beta
+          - release-candidate
+
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.BACKPORT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Cherry-pick onto ${{ matrix.target }} and open a backport PR
+        env:
+          GH_TOKEN: ${{ secrets.BACKPORT_TOKEN || secrets.GITHUB_TOKEN }}
+          TARGET: ${{ matrix.target }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          # ---- Skip cleanly if the target branch does not exist yet. --------
+          if ! git ls-remote --exit-code --heads origin "${TARGET}" >/dev/null 2>&1
+          then
+            echo "::notice::Target branch '${TARGET}' does not exist — nothing to backport."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin "${TARGET}"
+
+          BACKPORT_BRANCH="backport/pr-${PR_NUMBER}/${TARGET}"
+
+          # If a previous run already opened this backport, do nothing.
+          if git ls-remote --exit-code --heads origin "${BACKPORT_BRANCH}" >/dev/null 2>&1
+          then
+            echo "::notice::Backport branch '${BACKPORT_BRANCH}' already exists — skipping."
+            exit 0
+          fi
+
+          git checkout -B "${BACKPORT_BRANCH}" "origin/${TARGET}"
+
+          # ---- Cherry-pick the merged change. -------------------------------
+          # This repo merges PRs with merge commits, so MERGE_SHA is a merge
+          # commit and needs `-m 1` (its diff against the first parent is the
+          # PR's net change). A squash/rebase merge is a single-parent commit,
+          # so fall back to a plain cherry-pick.
+          CHERRY_OK="no"
+
+          set +e
+          git cherry-pick -m 1 "${MERGE_SHA}"
+          if [ "$?" -eq 0 ]
+          then
+            CHERRY_OK="yes"
+          else
+            git cherry-pick --abort 2>/dev/null
+            git cherry-pick "${MERGE_SHA}"
+            if [ "$?" -eq 0 ]
+            then
+              CHERRY_OK="yes"
+            fi
+          fi
+          set -e
+
+          # ---- Conflict path: push NOTHING, open a tracking issue. ----------
+          if [ "${CHERRY_OK}" != "yes" ]
+          then
+            git cherry-pick --abort 2>/dev/null || true
+
+            ISSUE_BODY="$(printf 'The automated backport of #%s ("%s") onto `%s` hit a merge conflict, so it was NOT pushed.\n\nThis is a dependency/security fix that landed on `main` and must also reach the `%s` tier. Please cherry-pick it by hand:\n\n```\ngit fetch origin\ngit checkout -B backport/pr-%s/%s origin/%s\ngit cherry-pick -m 1 %s   # resolve conflicts\ngit push -u origin backport/pr-%s/%s\n```\n\nOpened automatically by .github/workflows/backport-dependencies.yml.' \
+              "${PR_NUMBER}" "${PR_TITLE}" "${TARGET}" "${TARGET}" "${PR_NUMBER}" "${TARGET}" "${TARGET}" "${MERGE_SHA}" "${PR_NUMBER}" "${TARGET}")"
+
+            gh issue create \
+              --title "Manual backport needed: #${PR_NUMBER} → ${TARGET}" \
+              --label "infrastructure" \
+              --body "${ISSUE_BODY}" || echo "::warning::Could not open the tracking issue for ${TARGET}."
+
+            echo "::warning::Backport onto ${TARGET} conflicted; opened a tracking issue instead of pushing."
+            exit 0
+          fi
+
+          # ---- Clean path: push the branch + open the backport PR. ----------
+          git push -u origin "${BACKPORT_BRANCH}"
+
+          PR_BODY="$(printf 'Automated backport of #%s onto `%s`.\n\nDependabot *security* updates and GitHub security fixes only target the default branch (`main`), so this propagates the fix to the `%s` tier to keep it patched. Review and merge.\n\nOpened by .github/workflows/backport-dependencies.yml.' \
+            "${PR_NUMBER}" "${TARGET}" "${TARGET}")"
+
+          gh pr create \
+            --base "${TARGET}" \
+            --head "${BACKPORT_BRANCH}" \
+            --title "[Backport ${TARGET}] ${PR_TITLE}" \
+            --label "infrastructure" \
+            --body "${PR_BODY}" || echo "::warning::Branch pushed but PR create failed for ${TARGET} (open it manually)."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ on:
       - main
       - alpha
       - beta
+      - release-candidate
   pull_request:
 
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,48 @@
+# Lint GitHub Actions workflow files with actionlint.
+#
+# Added org-wide to catch real workflow bugs early — undefined `needs:`
+# jobs, malformed `${{ }}` expressions, invalid `runs-on`, deprecated
+# syntax, and genuine shell errors inside `run:` blocks. It is tuned to be
+# non-disruptive: the embedded shellcheck runs at `--severity=error`, so
+# cosmetic style/info/warning lint (SC2129 "group your redirects", SC2086
+# quoting info, …) never fails the build — only genuine breakage does.
+#
+# Runs only when workflow files change, so it costs no CI minutes on
+# ordinary code pushes.
+name: Lint Workflows
+
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+# Least-privilege: this job only reads the checked-out tree.
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-workflows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Install actionlint (pinned, checksum-verified by the official script)
+        run: |
+          bash <(curl -sSfL "https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash") 1.7.12
+
+      - name: Lint workflow files
+        env:
+          # Suppress cosmetic shellcheck style/info/warning; fail only on
+          # genuine errors (plus all of actionlint's own native checks).
+          SHELLCHECK_OPTS: --severity=error
+        run: ./actionlint -color

--- a/.github/workflows/sftp-deploy.yml
+++ b/.github/workflows/sftp-deploy.yml
@@ -73,6 +73,7 @@ on:
       - main
       - alpha
       - beta
+      - release-candidate
     paths:
       - 'web/**'
       - '.github/workflows/sftp-deploy.yml'


### PR DESCRIPTION
## 📋 Summary

Extends dependency/security coverage from **main-only** to **all four tiers** (`main` / `alpha` / `beta` / `release-candidate`), and closes the one gap `target-branch` can't: **security updates**.

## 🔑 The key distinction

| Update type | How it reaches non-`main` branches |
|---|---|
| Dependabot **version** updates (scheduled) | ✅ `target-branch:` per tier in `dependabot.yml` (now 4 entries) |
| Dependabot **security** updates (CVE patches) + GitHub security fixes | ❌ platform-limited to the **default branch only** → ✅ the new **backport workflow** |

## 🔄 Changes

- **`.github/dependabot.yml`** — add a `release-candidate` entry (version updates now open per-branch PRs against all four tiers; a not-yet-existent target is simply skipped until created).
- **`.github/workflows/backport-dependencies.yml`** *(new)* — when a `dependencies`/`security`/`infrastructure`-labelled PR **merges into `main`**, it cherry-picks the fix onto `alpha`/`beta`/`release-candidate` as fresh PRs. **Fail-safe:** skips a missing target branch, and on a cherry-pick **conflict it pushes nothing** — it opens a tracking issue for a manual backport instead. Runs no code from the merged PR (so `pull_request_target` is safe).
- **`.github/workflows/ci.yml` + `sftp-deploy.yml`** — add `release-candidate` to the push triggers.
- **`.github/workflows/lint.yml`** *(new on main)* — the actionlint job `alpha` already has, so workflows (incl. the new one) are linted on `main` too (also closes a drift).

## 🧑‍✈️ Owner actions to fully activate

1. **Create the `release-candidate` branch** — it doesn't exist yet. Recommended base is **`alpha`** (it holds all the launch-prep work and is the promotion source); everything here activates the moment it exists. Tell me and I'll cut it.
2. **Add a `BACKPORT_TOKEN` secret** (fine-grained PAT, `contents:write` + `pull-requests:write`) — PRs opened by the default `GITHUB_TOKEN` don't trigger CI (GitHub's recursion guard). With the PAT, backport PRs auto-run their checks; without it, they're still created but you re-run checks manually.
3. **Repo → Settings → Security:** enable **Dependabot security updates** + secret scanning + push protection (checklist item A2) — that's what generates the security PRs this workflow then backports.

## ✅ Testing

- [x] All 4 config/workflow files valid YAML; `dependabot.yml` targets `[main, alpha, beta, release-candidate]`.
- [x] Backport `run:` script passes `bash -n`; the new `lint.yml` runs **actionlint** on this PR to validate the workflow.

---

> Tracked on the [Go2My.Link Project Board](https://github.com/orgs/MWBMPartners/projects/4)

---
_Generated by [Claude Code](https://claude.ai/code/session_019v28sGYqnGeBSPNbGgVwgJ)_