### PR TITLE
ci(#194): codify ubuntu-latest as the required OS runner for all GitHub Actions

### DIFF
--- a/.claude/memory/patterns.md
+++ b/.claude/memory/patterns.md
@@ -71,6 +71,29 @@
 - YAML: valid syntax, proper indentation
 - SQL: valid syntax, consistent naming
 
+## 🚢 CI/CD & GitHub Actions (Standing Rule — ALL Projects)
+
+- **OS runner: `ubuntu-latest` for every job, always.** All GitHub Actions
+  workflows — CI (`ci.yml`), linting (`lint.yml`, `php-lint.yml`), the
+  dependency backport (`backport-dependencies.yml`), release (`release.yml`),
+  and **SFTP deploy (`sftp-deploy.yml`)** — run every job on `ubuntu-latest`.
+  Do NOT introduce `windows-*`, `macos-*`, or `self-hosted` runners. Rationale:
+  the production target (Dreamhost shared hosting) is Linux, so a Linux runner
+  keeps PHP, the lint toolchain, and the `lftp`/SFTP deploy tooling at
+  dev/CI/deploy parity; `ubuntu-latest` is also the fastest, free, best-supported
+  runner. **When adding any new workflow or job, set `runs-on: ubuntu-latest`.**
+- **Keep `ci.yml`'s single-value matrix.** `ci.yml` deliberately expresses the
+  runner as `os: [ubuntu-latest]` → `runs-on: ${{ matrix.os }}`. That single
+  matrix value is what makes GitHub render the required status-check contexts as
+  `Frontend (ubuntu-latest)` / `Backend (ubuntu-latest)` for the "Protect main
+  branch" ruleset. Keep the matrix (and keep it `ubuntu-latest`); collapsing it
+  to a bare `runs-on` orphans the required checks and soft-locks every PR to main.
+- **Pin actions by commit SHA**, not by floating tag — e.g.
+  `actions/checkout@<sha>  # v7.0.1`. Dependabot (`github-actions` ecosystem)
+  keeps the pins current across all four tiers (main/alpha/beta/release-candidate);
+  security patches merged on `main` fan out to the other tiers via
+  `backport-dependencies.yml`.
+
 ## 🐘 PHP Standards
 
 - PHP 8.5+ with 8.4 backward compat via `version_compare()`

--- a/.github/workflows/sftp-deploy.yml
+++ b/.github/workflows/sftp-deploy.yml
@@ -118,6 +118,11 @@
 #   SFTP_ENABLED      Set to 'true' to arm deployment (kill switch; off by default)
 #
 # ---------------------------------------------------------------------------
+# RUNNER — both jobs run on `ubuntu-latest` (house rule, see
+# .claude/memory/patterns.md → "CI/CD & GitHub Actions"). The production target
+# (Dreamhost) is Linux, so a Linux runner keeps the PHP + lftp/SFTP toolchain at
+# dev/CI/deploy parity. Do NOT switch any job to windows-*/macos-*/self-hosted.
+# ---------------------------------------------------------------------------
 # GeoIP DATABASE DEPLOYMENT (#43) — read before touching the mirror commands
 # ---------------------------------------------------------------------------
 # web/_libraries/maxminddb/*.mmdb is EXCLUDED from every `--delete` mirror

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -46,6 +46,11 @@
   get **per-user analytics** with a proven data-isolation guarantee (a
   non-owning user's `[default]` aggregate returns 0) + two extra
   ownership-leak fixes in the analytics export + API v1 handlers.
+- **CI runner convention codified (#194):** audited every workflow on every tier
+  — all jobs already run on `ubuntu-latest` (no windows/macos/self-hosted),
+  including both `sftp-deploy.yml` jobs. Recorded the standing rule in
+  `.claude/memory/patterns.md` ("CI/CD & GitHub Actions") + a point-of-use note
+  in `sftp-deploy.yml` so future workflows stay on `ubuntu-latest`.
 - ⚠️ Still true: do **NOT** merge stale `main` down into `alpha`/`beta`/`release-candidate`.
 
 ### 🗓️ 2026-07-22 update (automation session)


### PR DESCRIPTION
## Summary

Audit + convention. **Every job in every workflow on every tier already runs on `ubuntu-latest`** — no `windows-*`/`macos-*`/`self-hosted` runners anywhere, including both jobs of the SFTP deploy workflow. Nothing needed fixing; this records the convention so future workflows don't drift.

## Changes

- [x] `.claude/memory/patterns.md` — new **"CI/CD & GitHub Actions"** standing rule: `ubuntu-latest` for every job; no Windows/macOS/self-hosted; new workflows set `runs-on: ubuntu-latest`; keep `ci.yml`'s single-value `os` matrix (it renders the required `(ubuntu-latest)` check contexts for the "Protect main branch" ruleset); pin actions by SHA.
- [x] `.github/workflows/sftp-deploy.yml` — point-of-use runner note in the header (both jobs run on `ubuntu-latest`; do not switch runner type).
- [x] `HANDOFF.md` — record the audit + convention.

## Component(s)

- [x] CI/CD / Infrastructure

## Audit result (`runs-on` across all workflows / tiers)

| Workflow | Runner |
|---|---|
| `sftp-deploy.yml` (`checks` + `deploy`, all tiers) | `ubuntu-latest` |
| `ci.yml` (`frontend`/`backend`/`tests-integration`, via `os: [ubuntu-latest]` matrix) | `ubuntu-latest` |
| `lint.yml`, `php-lint.yml`, `release.yml`, `backport-dependencies.yml` | `ubuntu-latest` |

## Testing

- [x] `sftp-deploy.yml` YAML parses
- [x] No behavioural change — comment + docs only; no `runs-on` value changed (they were already correct)
- actionlint runs as a required check via `lint.yml`

## Related Issues

Closes #194

---

> Tracked on the [Go2My.Link Project Board](https://github.com/orgs/MWBMPartners/projects/4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019v28sGYqnGeBSPNbGgVwgJ)_